### PR TITLE
feat: strategies — dummies + bayesian-simple with benchmarks

### DIFF
--- a/project/results/bayesian.md
+++ b/project/results/bayesian.md
@@ -1,0 +1,68 @@
+# Bayesian-Simple Strategy Benchmark Results
+
+**Date:** 2026-04-28
+**Games per config:** 1000
+**Strategy:** bayesian-simple (K=200 Monte Carlo samples, 1-turn lookahead, uniform prior)
+
+---
+
+## bayesian-simple vs random
+
+| Players | Win Rate | Avg Score | Median | Expected (1/N) | Relative | Random Avg Score |
+|---------|----------|-----------|--------|----------------|----------|-----------------|
+| 3       | 74.5%    | 37.4      | 36     | 33.3%          | 2.24x    | 61.7            |
+| 4       | 69.8%    | 32.7      | 30     | 25.0%          | 2.79x    | 57.0            |
+| 5       | 64.5%    | 29.8      | 28     | 20.0%          | 3.23x    | 54.5            |
+| 6       | 54.1%    | 30.4      | 28     | 16.7%          | 3.24x    | 51.8            |
+| 7       | 43.1%    | 32.1      | 30     | 14.3%          | 3.01x    | 49.8            |
+| 8       | 34.9%    | 33.4      | 32     | 12.5%          | 2.79x    | 48.6            |
+| 9       | 27.9%    | 33.7      | 32     | 11.1%          | 2.51x    | 46.6            |
+| 10      | 24.1%    | 35.5      | 34     | 10.0%          | 2.41x    | 46.4            |
+
+---
+
+## Head-to-head: bayesian-simple vs dummy-max vs random (5 players)
+
+| Strategy        | Win Rate | Avg Score | Median | Min | Max | StdDev |
+|-----------------|----------|-----------|--------|-----|-----|--------|
+| bayesian-simple | 48.2%    | 33.7      | 32     | 0   | 94  | 17.7   |
+| dummy-max       | 28.6%    | 41.0      | 40     | 2   | 94  | 17.8   |
+| random (pooled) | 8.7%     | 56.9      | 59     | 1   | 111 | 18.8   |
+
+## Head-to-head: bayesian-simple vs dummy-min vs dummy-max vs random (5 players)
+
+| Strategy        | Win Rate | Avg Score | Median | Min | Max | StdDev |
+|-----------------|----------|-----------|--------|-----|-----|--------|
+| bayesian-simple | 64.1%    | 28.2      | 27     | 0   | 87  | 16.6   |
+| dummy-max       | 19.6%    | 42.6      | 41     | 4   | 93  | 17.7   |
+| dummy-min       | 3.2%     | 63.9      | 67     | 3   | 113 | 17.9   |
+| random (pooled) | 7.7%     | 53.5      | 54     | 6   | 106 | 18.7   |
+
+---
+
+## Comparison with dummy-max baseline
+
+Win rates when each strategy is seat 0 vs (N-1) random opponents:
+
+| Players | bayesian-simple | dummy-max | random (expected) |
+|---------|----------------|-----------|-------------------|
+| 3       | 74.5%          | 40.7%     | 33.3%             |
+| 4       | 69.8%          | 46.4%     | 25.0%             |
+| 5       | 64.5%          | 38.2%     | 20.0%             |
+| 6       | 54.1%          | 29.9%     | 16.7%             |
+| 7       | 43.1%          | 20.7%     | 14.3%             |
+| 8       | 34.9%          | 16.6%     | 12.5%             |
+| 9       | 27.9%          | 13.5%     | 11.1%             |
+| 10      | 24.1%          | 12.5%     | 10.0%             |
+
+---
+
+## Analysis
+
+- **bayesian-simple dominates random** at every player count, with a relative win-rate advantage of 2.2x–3.2x over the expected 1/N baseline. This far exceeds dummy-max's 1.2x–1.9x range.
+- **Peak relative advantage at 5–6 players** (~3.2x), where Monte Carlo lookahead best exploits the moderate row congestion. At 3 players the absolute win rate is highest (74.5%) but relative gain is lower because even random wins often in small fields.
+- **Beats dummy-max head-to-head**: In the 5-player mixed game, bayesian-simple wins 48.2% vs dummy-max's 28.6% — a 1.69x advantage over the next-best heuristic.
+- **Score advantage is substantial**: bayesian-simple's average score (30–37) is consistently 15–25 points lower (better) than pooled random (47–62), and ~7–10 points better than dummy-max (~41–55).
+- **Scaling with player count**: As players increase from 3→10, bayesian-simple's win rate drops from 74.5%→24.1%, but always stays well above expected. The strategy remains effective even in crowded 10-player games (2.4x relative).
+- **dummy-min remains the weakest strategy**: In the 3-way head-to-head, dummy-min wins only 3.2% — worse than random (7.7%) — confirming that always playing the lowest card is actively harmful.
+- **Performance note**: Simulations with bayesian-simple are slow due to Monte Carlo sampling (~10–15 minutes per 1000-game config at higher player counts). This is expected given K=200 samples per decision.

--- a/project/results/dummies.md
+++ b/project/results/dummies.md
@@ -1,0 +1,44 @@
+# Dummy Strategies Benchmark Results
+
+**Date:** 2026-04-28
+**Games per config:** 1000
+**Setup:** 1 dummy strategy + (N-1) random players
+
+---
+
+## dummy-min vs random
+
+| Players | Win Rate | Avg Score | Expected (1/N) | Relative |
+|---------|----------|-----------|----------------|----------|
+| 3 | 17.2% | 64.6 | 33.3% | 0.52x |
+| 4 | 16.6% | 59.2 | 25% | 0.66x |
+| 5 | 13% | 57.8 | 20% | 0.65x |
+| 6 | 10.4% | 56.3 | 16.7% | 0.62x |
+| 7 | 8.4% | 54.3 | 14.3% | 0.59x |
+| 8 | 11.3% | 49.8 | 12.5% | 0.9x |
+| 9 | 7.7% | 50.5 | 11.1% | 0.69x |
+| 10 | 8.7% | 47.9 | 10% | 0.87x |
+
+## dummy-max vs random
+
+| Players | Win Rate | Avg Score | Expected (1/N) | Relative |
+|---------|----------|-----------|----------------|----------|
+| 3 | 40.7% | 54.5 | 33.3% | 1.22x |
+| 4 | 46.4% | 43.5 | 25% | 1.86x |
+| 5 | 38.2% | 40.9 | 20% | 1.91x |
+| 6 | 29.9% | 41.1 | 16.7% | 1.79x |
+| 7 | 20.7% | 42.8 | 14.3% | 1.45x |
+| 8 | 16.6% | 44.5 | 12.5% | 1.33x |
+| 9 | 13.5% | 42.9 | 11.1% | 1.22x |
+| 10 | 12.5% | 43.0 | 10% | 1.25x |
+
+---
+
+## Analysis
+
+- **dummy-max** consistently outperforms random across all player counts (1.2x–1.9x relative win rate).
+- **dummy-min** consistently underperforms random (0.5x–0.9x) — always playing the lowest card forces frequent row picks.
+- **dummy-max peaks at 4–5 players** (~1.9x relative advantage), where the strategy benefits most from resolving last while rows haven't filled yet.
+- At higher player counts (7–10), dummy-max's advantage diminishes as rows fill faster and even high cards can trigger overflows.
+- **dummy-min's avg score improves** with more players (64.6 → 47.9) because penalties are distributed across more players, but it still loses more often.
+

--- a/spec/data-capture.md
+++ b/spec/data-capture.md
@@ -1,0 +1,216 @@
+# Data Capture Specification
+
+## Purpose
+
+Capture full game logs from live multiplayer sessions (e.g., BGA) to build a dataset for:
+
+1. **Replay** — re-run games offline with different strategies to measure what-if performance
+2. **Modelling** — train opponent models from observed human play patterns
+3. **Benchmarking** — compare strategy versions against the same real-game scenarios
+4. **Debugging** — inspect decision quality after the fact
+
+---
+
+## What to Capture
+
+### Per-Game Metadata
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `gameId` | string | Unique identifier (BGA game ID or UUID) |
+| `source` | string | Platform (e.g., `"bga"`, `"local"`) |
+| `timestamp` | ISO 8601 | When the game started |
+| `playerCount` | number | 2–10 |
+| `players` | Player[] | Player info (id, name, isUs, strategy used) |
+| `finalScores` | Record<id, number> | End-of-game scores |
+| `winner` | string | Player ID of winner |
+| `totalRounds` | number | Rounds played |
+
+### Per-Round Data
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `round` | number | Round number (1-based) |
+| `initialBoard` | number[][] | The 4 starter cards |
+| `dealtHand` | number[] | Our hand for this round |
+| `turns` | Turn[] | All 10 turns |
+| `roundScores` | Record<id, number> | Points collected this round per player |
+
+### Per-Turn Data
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `turn` | number | Turn number (1–10) |
+| `ourCard` | number | The card we played |
+| `ourRecommendation` | number \| null | What the strategy recommended (null if no strategy active) |
+| `plays` | { playerId, card }[] | All revealed cards |
+| `resolutions` | Resolution[] | Placement results (row, overflow, collected) |
+| `rowPicks` | RowPick[] | Any forced row picks |
+| `boardBefore` | number[][] | Board state before resolution |
+| `boardAfter` | number[][] | Board state after resolution |
+
+### Per-Decision Context (optional, for model training)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `hand` | number[] | Hand at decision time |
+| `board` | number[][] | Board at decision time |
+| `strategyUsed` | string | Strategy that made the recommendation |
+| `confidence` | number \| null | Strategy's confidence in the pick |
+| `alternatives` | { card, score }[] | Other options the strategy considered |
+| `timeToDecide` | number | Milliseconds taken |
+
+---
+
+## Storage Format
+
+### File-based (primary)
+
+One JSON file per game, stored in a local `data/games/` directory:
+
+```
+data/
+  games/
+    2026-04-28_bga_12345678.json
+    2026-04-28_bga_12345679.json
+    ...
+  index.json   # lightweight manifest
+```
+
+Each file is a self-contained `GameLog` object:
+
+```typescript
+interface GameLog {
+  version: 1;
+  metadata: GameMetadata;
+  rounds: RoundLog[];
+}
+```
+
+### Index File
+
+Quick lookup without parsing every game file:
+
+```typescript
+interface GameIndex {
+  games: {
+    file: string;
+    gameId: string;
+    source: string;
+    timestamp: string;
+    playerCount: number;
+    winner: string;
+    ourStrategy: string | null;
+    ourFinalScore: number;
+    ourRank: number;
+  }[];
+}
+```
+
+---
+
+## Capture Points
+
+### During Live Play (via MCP agent)
+
+The agent already calls `turn_resolved` and `round_ended` — we can hook into the session lifecycle:
+
+1. **`round_started`** → log `initialBoard` + `dealtHand`
+2. **`session_recommend`** → log decision context (hand, board, recommendation, alternatives)
+3. **`turn_resolved`** → log full turn data (plays, resolutions, boardAfter)
+4. **`round_ended`** → log round scores
+5. **`end_session`** → finalize and write game file
+
+### Post-Hoc (manual data entry)
+
+For games played without the agent, allow importing from BGA replay URLs or manual JSON entry.
+
+---
+
+## Replay Engine
+
+Given a `GameLog`, we can re-run the game with a different strategy:
+
+```bash
+npx tsx src/cli/index.ts replay --game data/games/2026-04-28_bga_12345678.json --strategy bayesian-simple
+```
+
+The replay engine:
+1. Loads the game log
+2. Replays each round with the real board and real opponent plays
+3. Substitutes **our** card choice with the specified strategy's recommendation
+4. Tracks what _would have happened_ (note: changing our play changes resolution order, which changes everything downstream)
+
+### Counterfactual vs Fixed-Opponent Replay
+
+| Mode | Description | Use Case |
+|------|-------------|----------|
+| **Fixed-opponent** | Opponents play exactly as logged; only our play changes | Fast, good for "what if I had played X instead" |
+| **Counterfactual** | Re-simulate full resolution with our changed play | More accurate but requires full placement engine |
+
+**Recommendation:** Start with fixed-opponent replay. It's simpler and the most common use case ("would bayesian have done better here?").
+
+---
+
+## Dataset Operations
+
+### Filter & Query
+
+```bash
+# List all games where we lost
+npx tsx src/cli/index.ts data list --filter "ourRank > 1"
+
+# Show stats across all captured games
+npx tsx src/cli/index.ts data stats
+
+# Export turns where strategy disagreed with our play
+npx tsx src/cli/index.ts data export-disagreements --strategy bayesian-simple
+```
+
+### Bulk Replay
+
+```bash
+# Replay all games with a strategy, output comparative stats
+npx tsx src/cli/index.ts data bulk-replay --strategy bayesian-simple --format table
+```
+
+---
+
+## Privacy & Data Handling
+
+- **No storage of other players' real names** — use anonymized IDs (e.g., `opponent-1`, `opponent-2`)
+- **Local storage only** — game data stays in `data/` directory, not committed to git
+- **`.gitignore`** — `data/games/` is git-ignored; only `data/.gitkeep` is tracked
+- **Optional anonymization** — strip BGA-specific IDs before sharing datasets
+
+---
+
+## Implementation Phases
+
+### Phase 1: Capture Infrastructure
+- Define `GameLog` TypeScript types
+- Add capture hooks to MCP session lifecycle
+- Write game files on `end_session`
+- Basic `data list` CLI command
+
+### Phase 2: Replay
+- Fixed-opponent replay engine
+- `replay` CLI command
+- Comparative stats output (original vs strategy)
+
+### Phase 3: Analysis
+- Bulk replay across dataset
+- Disagreement extraction (where strategy would have played differently)
+- Per-player opponent modelling from observed plays
+
+---
+
+## Open Questions
+
+1. **Capture granularity:** Should we log _every_ intermediate state, or just turn boundaries? Turn boundaries are sufficient for replay but intermediate states help debug strategy internals.
+
+2. **BGA data extraction:** Can we reliably extract opponent plays from BGA's DOM/API, or do we need to infer from board state diffs? This depends on the Playwright integration.
+
+3. **Dataset size requirements:** How many games do we need before opponent modelling becomes meaningful? Likely 50-100+ games against the same player pool.
+
+4. **Versioning:** If we change the game engine (e.g., variant rules), old logs may become incompatible. The `version: 1` field handles this, but migration tooling may be needed.

--- a/spec/data-capture.md
+++ b/spec/data-capture.md
@@ -17,13 +17,13 @@ Capture full game logs from live multiplayer sessions (e.g., BGA) to build a dat
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `gameId` | string | Unique identifier (BGA game ID or UUID) |
+| `gameId` | string | UUID (generated locally, not from BGA) |
 | `source` | string | Platform (e.g., `"bga"`, `"local"`) |
-| `timestamp` | ISO 8601 | When the game started |
+| `timestamp` | ISO 8601 | Date only (no time — reduces traceability) |
 | `playerCount` | number | 2–10 |
-| `players` | Player[] | Player info (id, name, isUs, strategy used) |
-| `finalScores` | Record<id, number> | End-of-game scores |
-| `winner` | string | Player ID of winner |
+| `players` | Player[] | Seat info (seatIndex, isUs, strategy used if us) |
+| `finalScores` | Record<seat, number> | End-of-game scores by seat index |
+| `winner` | string | Seat label of winner (e.g., `"us"` or `"seat-2"`) |
 | `totalRounds` | number | Rounds played |
 
 ### Per-Round Data
@@ -34,7 +34,7 @@ Capture full game logs from live multiplayer sessions (e.g., BGA) to build a dat
 | `initialBoard` | number[][] | The 4 starter cards |
 | `dealtHand` | number[] | Our hand for this round |
 | `turns` | Turn[] | All 10 turns |
-| `roundScores` | Record<id, number> | Points collected this round per player |
+| `roundScores` | Record<seat, number> | Points collected this round per seat |
 
 ### Per-Turn Data
 
@@ -43,7 +43,7 @@ Capture full game logs from live multiplayer sessions (e.g., BGA) to build a dat
 | `turn` | number | Turn number (1–10) |
 | `ourCard` | number | The card we played |
 | `ourRecommendation` | number \| null | What the strategy recommended (null if no strategy active) |
-| `plays` | { playerId, card }[] | All revealed cards |
+| `plays` | { seat, card }[] | All revealed cards (by seat index) |
 | `resolutions` | Resolution[] | Placement results (row, overflow, collected) |
 | `rowPicks` | RowPick[] | Any forced row picks |
 | `boardBefore` | number[][] | Board state before resolution |
@@ -97,9 +97,8 @@ interface GameIndex {
     file: string;
     gameId: string;
     source: string;
-    timestamp: string;
+    date: string;
     playerCount: number;
-    winner: string;
     ourStrategy: string | null;
     ourFinalScore: number;
     ourRank: number;
@@ -178,10 +177,12 @@ npx tsx src/cli/index.ts data bulk-replay --strategy bayesian-simple --format ta
 
 ## Privacy & Data Handling
 
-- **No storage of other players' real names** — use anonymized IDs (e.g., `opponent-1`, `opponent-2`)
-- **Local storage only** — game data stays in `data/` directory, not committed to git
-- **`.gitignore`** — `data/games/` is git-ignored; only `data/.gitkeep` is tracked
-- **Optional anonymization** — strip BGA-specific IDs before sharing datasets
+- **No player identity data stored** — opponents are referenced only as `seat-0`, `seat-1`, etc. based on position. No usernames, BGA IDs, profile links, or any traceable identifiers are captured.
+- **Our own identity** is stored as `"us"` — no account name.
+- **No cross-game player tracking** — each game's seat labels are independent. There is no way to correlate `seat-2` in game A with `seat-2` in game B (they may be different people).
+- **Local storage only** — game data stays in `data/` directory, not committed to git.
+- **`.gitignore`** — `data/games/` is git-ignored; only `data/.gitkeep` is tracked.
+- **No BGA-specific metadata** — no table IDs, room names, or timestamps that could identify a specific BGA session.
 
 ---
 
@@ -211,6 +212,6 @@ npx tsx src/cli/index.ts data bulk-replay --strategy bayesian-simple --format ta
 
 2. **BGA data extraction:** Can we reliably extract opponent plays from BGA's DOM/API, or do we need to infer from board state diffs? This depends on the Playwright integration.
 
-3. **Dataset size requirements:** How many games do we need before opponent modelling becomes meaningful? Likely 50-100+ games against the same player pool.
+3. **Dataset size requirements:** How many games do we need before opponent modelling becomes meaningful? Likely 50-100+ games. Since we don't track player identity across games, modelling is against "generic human" play patterns rather than specific individuals.
 
 4. **Versioning:** If we change the game engine (e.g., variant rules), old logs may become incompatible. The `version: 1` field handles this, but migration tooling may be needed.

--- a/spec/strategies/bayesian.md
+++ b/spec/strategies/bayesian.md
@@ -1,0 +1,205 @@
+# Bayesian Strategy for 6 Nimmt!
+
+## Overview
+
+A Bayesian strategy maintains a **probability distribution over unobserved cards** (opponents' hands) and uses it to estimate the expected penalty of each possible play. It updates beliefs after each turn based on revealed information.
+
+---
+
+## Information Available
+
+At any decision point, the strategy knows:
+
+| Source | Information |
+|--------|-------------|
+| Own hand | Exact cards remaining |
+| Board | 4 rows with all visible cards |
+| Turn history | All plays from all previous turns (who played what, where it landed) |
+| Initial board | The 4 starter cards for this round |
+| Player count | N players (2–10) |
+| Round/turn | Position in game |
+| Scores | Cumulative penalties per player |
+
+### Derivable Knowledge
+
+From the above, we can compute the **unobserved card pool**:
+
+```
+allCards = {1..104}
+knownCards = hand ∪ boardCards ∪ allPlayedCards (from turnHistory)
+unknownPool = allCards \ knownCards
+```
+
+At turn T, `unknownPool` has `104 - 4(board starters) - 10(my hand dealt) - (N-1)×10(opponents dealt)` at start, minus all revealed cards. Since each player plays one card per turn, after T-1 turns we've observed `(T-1) × N` plays.
+
+**Key insight:** We don't know _which_ cards are in _which_ opponent's hand, but we know the _pool_ they were dealt from, and we observe their plays over time.
+
+---
+
+## Core Model: Card Location Beliefs
+
+### State Representation
+
+For each card `c` in `unknownPool`, maintain a probability distribution over its location:
+
+```
+P(card c is in player i's hand | observations so far)
+```
+
+At round start (before any plays), the prior is uniform:
+```
+P(c ∈ hand_i) = (10 - turnsPlayed) / |unknownPool|   for each opponent i
+```
+
+Since each opponent has `(10 - turnsPlayed)` cards remaining out of the unknown pool.
+
+### Bayesian Updates
+
+After each turn resolves, update beliefs:
+
+1. **Direct elimination:** Card played by opponent i → remove from pool, P = 0 for all other locations.
+2. **Indirect inference (optional, advanced):** If opponent i played card X, they _chose_ X over their other cards. Under an assumed opponent model (e.g., "opponents play somewhat rationally"), this makes certain cards more/less likely to be in their hand.
+
+#### Simple Update (no opponent modelling)
+
+After turn T where opponent i plays card c_i:
+- Remove c_i from unknownPool
+- Remaining cards redistributed uniformly among remaining hand slots
+
+#### Advanced Update (opponent modelling)
+
+Assume opponents play with a rough heuristic (e.g., "play a card close to but above a row tail"). If opponent i played 47 when a row tail is 45, infer they're more likely to hold cards near row tails. This is computationally expensive and may have diminishing returns vs. simple tracking.
+
+**Recommendation:** Start with simple uniform tracking. Add opponent modelling as a later enhancement.
+
+---
+
+## Decision: Card Choice
+
+For each card `c` in my hand, estimate:
+
+```
+E[penalty(c)] = Σ over possible opponent plays × P(those plays) × penalty(c given those plays)
+```
+
+### Simplified Monte Carlo Estimation
+
+Exact computation is intractable (combinatorial explosion of opponent hand assignments). Use sampling:
+
+1. **Sample K scenarios** from the belief distribution:
+   - For each scenario, assign remaining unknown cards to opponents randomly (respecting hand size constraints)
+   - For each opponent, sample a play using a simple heuristic (e.g., uniform random from their assigned hand)
+
+2. **For each of my candidate cards**, simulate placement given each scenario:
+   - Determine resolution order (ascending across all plays)
+   - Compute which row the card lands on
+   - Check if it causes overflow (6th card) or forces a row pick
+   - Compute expected cattle heads collected
+
+3. **Pick the card with lowest expected penalty.**
+
+### Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `K` (samples) | Number of Monte Carlo scenarios | 200 |
+| `opponentModel` | How to sample opponent plays | `"uniform"` |
+| `riskWeight` | How much to weight overflow risk vs. average penalty | 1.0 |
+| `lookAhead` | Turns to simulate ahead (1 = immediate, 2+ = multi-turn) | 1 |
+
+---
+
+## Decision: Row Choice
+
+When forced to pick a row (card lower than all tails), the decision is deterministic given current state — no uncertainty. Use a greedy heuristic:
+
+1. **Fewest cattle heads** (default — same as dummy strategies)
+2. **Row length consideration** — prefer taking short rows (fewer penalty cards) even if individual cards are heavier
+3. **Future board value** — prefer leaving the board in a state favourable for remaining hand cards
+
+Option 3 requires lookahead and is a potential enhancement.
+
+**Recommendation:** Start with fewest-cattle-heads. Revisit after measuring card-choice improvements.
+
+---
+
+## Computational Budget
+
+| Player count | Unknown pool (turn 1) | Possible assignments | Feasible? |
+|---|---|---|---|
+| 2 | 80 cards, 1 opponent × 10 | C(80,10) ≈ 1.6×10^12 | Monte Carlo only |
+| 5 | 50 cards, 4 opponents × 10 | Astronomical | Monte Carlo only |
+| 10 | 0 cards at start (all dealt!) | Exactly 1 assignment | Can be computed exactly! |
+
+**Special case:** In a 10-player game, `10×10 + 4 = 104` — the entire deck is dealt. After observing each opponent's first play, we can narrow possibilities significantly. By mid-round, we can often _deterministically_ know opponents' hands.
+
+---
+
+## Strategy Variants
+
+### `bayesian-simple`
+- Uniform prior over card locations
+- No opponent modelling (opponents play uniform random)
+- K=200 samples, 1-turn lookahead
+- Fewest-heads row pick
+- **Target:** 20-30% improvement over random
+
+### `bayesian-adaptive` (future)
+- Same as simple, but learn opponent tendencies from turn history
+- Weight opponent play sampling by observed patterns (e.g., "this player tends to play high cards")
+- K=500 samples
+- **Target:** 5-10% improvement over bayesian-simple
+
+### `bayesian-deep` (future)
+- Multi-turn lookahead (2-3 turns)
+- Board state evaluation function for row picks
+- Opponent modelling with per-player profiles
+- K=1000 samples
+- **Target:** Additional 5% over adaptive
+
+---
+
+## Implementation Considerations
+
+### Performance
+
+The strategy must run within MCP timeout (default: 5000ms per decision). Budget:
+- 200 samples × N opponents × placement simulation ≈ 1-5ms per card candidate
+- 10 cards in hand × 5ms = 50ms per decision
+- Well within budget for `bayesian-simple`
+
+### State Tracking
+
+The strategy uses `onTurnResolved()` to maintain:
+- `unknownPool: Set<CardNumber>` — cards not yet observed
+- `opponentHandSizes: Map<string, number>` — remaining cards per opponent
+- `playHistory: Map<string, CardNumber[]>` — what each opponent has played
+
+### Integration with Engine
+
+```typescript
+interface BayesianConfig {
+  samples: number;           // Monte Carlo samples (default: 200)
+  opponentModel: 'uniform' | 'heuristic';
+  riskWeight: number;        // Penalty weight (default: 1.0)
+  lookAhead: number;         // Turns ahead (default: 1)
+}
+```
+
+The strategy implements the standard `Strategy` interface — no engine changes needed.
+
+---
+
+## Open Questions
+
+1. **Opponent modelling value:** Is it worth modelling opponents as non-random? The marginal improvement may not justify the complexity. Need empirical testing.
+
+2. **Sample count sensitivity:** How does performance scale with K? Diminishing returns likely set in around K=100-500. Need to benchmark.
+
+3. **10-player determinism:** In a 10-player game, we can often reconstruct opponent hands exactly by mid-round. Should we have a special fast-path for this case?
+
+4. **Row pick lookahead:** Is the naive "fewest heads" heuristic actually optimal? Could consider: "which row, if I take it, leaves the best board state for my remaining cards?"
+
+5. **Risk aversion:** Should the strategy minimize _expected_ penalty (risk-neutral) or minimize _worst-case_ penalty (risk-averse)? A risk-averse variant might perform better in competitive settings.
+
+6. **Card value heuristic:** Even without Monte Carlo, a fast heuristic could be: "play the card whose placement row has the most available slots (fewest existing cards)". How does this compare to full Bayesian sampling?

--- a/spec/strategies/dummies.md
+++ b/spec/strategies/dummies.md
@@ -1,0 +1,38 @@
+# Dummy Strategies: `dummy-min` and `dummy-max`
+
+## Purpose
+
+These are deterministic baseline strategies used for benchmarking. They apply the simplest possible card selection logic with no intelligence, making them useful as lower-bound references when evaluating smarter strategies.
+
+## `dummy-min`
+
+**Card choice:** Always plays the lowest-valued card in hand.
+
+**Row choice:** Picks the row with the fewest total cattle heads (same heuristic as `random`).
+
+**Rationale:** Low cards are more likely to be lower than all row tails, forcing row picks. This strategy should perform poorly and accumulate penalties quickly.
+
+## `dummy-max`
+
+**Card choice:** Always plays the highest-valued card in hand.
+
+**Row choice:** Picks the row with the fewest total cattle heads (same heuristic as `random`).
+
+**Rationale:** High cards are placed last in resolution order (ascending), meaning they see all other players' cards placed first. This can sometimes avoid triggering the 6th-card overflow, but also means they always land at the end of rows, pushing them closer to 5 cards. Performance relative to `dummy-min` is an empirical question.
+
+## Shared Behaviour
+
+- No state tracking (`onTurnResolved` / `onRoundEnd` are no-ops).
+- No RNG dependency — fully deterministic.
+- Player count range: 2–10 (same as `random`).
+- Row choice heuristic: fewest cattle heads (greedy penalty avoidance).
+
+## Expected Use
+
+```bash
+# Compare dummies against each other and random
+npx tsx src/cli/main.ts simulate -s dummy-min,dummy-max,random,random -n 1000
+
+# Use as benchmarks for smarter strategies
+npx tsx src/cli/main.ts simulate -s bayesian,dummy-min,dummy-max,random -n 1000
+```

--- a/src/engine/strategies/bayesian.ts
+++ b/src/engine/strategies/bayesian.ts
@@ -1,0 +1,165 @@
+import type { Strategy, TurnResolution } from './types';
+import type { CardNumber, Board } from '../types';
+import { cattleHeads } from '../card';
+
+const K = 200; // Monte Carlo samples per decision
+
+function fewestHeadsRowIndex(rows: readonly (readonly CardNumber[])[]): 0 | 1 | 2 | 3 {
+  let best = 0;
+  let bestP = Infinity;
+  for (let i = 0; i < rows.length; i++) {
+    const p = rows[i].reduce((s, c) => s + cattleHeads(c), 0);
+    if (p < bestP) {
+      bestP = p;
+      best = i;
+    }
+  }
+  return best as 0 | 1 | 2 | 3;
+}
+
+/** Simulate placing all plays onto the board, return penalty for targetCard's owner. */
+function simulateTurn(
+  plays: { card: CardNumber; isMe: boolean }[],
+  board: CardNumber[][],
+): number {
+  const sorted = [...plays].sort((a, b) => a.card - b.card);
+  let penalty = 0;
+
+  for (const play of sorted) {
+    // Find best row: tail < card and largest such tail
+    let bestRow = -1;
+    let bestTail = -1;
+    for (let i = 0; i < board.length; i++) {
+      const tail = board[i][board[i].length - 1];
+      if (tail < play.card && tail > bestTail) {
+        bestTail = tail;
+        bestRow = i;
+      }
+    }
+
+    if (bestRow === -1) {
+      // Card lower than all tails — forced row pick (fewest heads)
+      const rowIdx = fewestHeadsRowIndex(board);
+      if (play.isMe) {
+        penalty += board[rowIdx].reduce((s, c) => s + cattleHeads(c), 0);
+      }
+      board[rowIdx] = [play.card];
+    } else if (board[bestRow].length >= 5) {
+      // Overflow: 6th card
+      if (play.isMe) {
+        penalty += board[bestRow].reduce((s, c) => s + cattleHeads(c), 0);
+      }
+      board[bestRow] = [play.card];
+    } else {
+      board[bestRow].push(play.card);
+    }
+  }
+
+  return penalty;
+}
+
+/** Deep-copy board rows into mutable arrays. */
+function cloneBoard(board: Board): CardNumber[][] {
+  return board.rows.map((row) => [...row]);
+}
+
+/** Fisher-Yates shuffle (in-place) using provided rng. */
+function fisherYates<T>(arr: T[], rng: () => number): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+  }
+  return arr;
+}
+
+export function createBayesianSimpleStrategy(): Strategy {
+  let rng: () => number = Math.random;
+  let playerCount = 2;
+  let seenCards = new Set<number>();
+
+  return {
+    name: 'bayesian-simple',
+
+    onGameStart(config) {
+      rng = config.rng;
+      playerCount = config.playerCount;
+      seenCards = new Set();
+    },
+
+    onTurnResolved(resolution: TurnResolution) {
+      for (const play of resolution.plays) {
+        seenCards.add(play.card);
+      }
+    },
+
+    chooseCard(state) {
+      const { hand, board, turn } = state;
+      const opponentCount = playerCount - 1;
+      const cardsPerPlayer = 10 - turn + 1; // cards remaining in each hand
+
+      // Build unknown pool
+      const known = new Set<number>();
+      for (const c of hand) known.add(c);
+      for (const row of board.rows) {
+        for (const c of row) known.add(c);
+      }
+      for (const c of seenCards) known.add(c);
+      // Also include initial board cards and turnHistory plays
+      for (const entry of state.turnHistory) {
+        for (const play of entry.plays) known.add(play.card);
+      }
+      for (const row of state.initialBoardCards.rows) {
+        for (const c of row) known.add(c);
+      }
+
+      const unknownPool: CardNumber[] = [];
+      for (let i = 1; i <= 104; i++) {
+        if (!known.has(i)) unknownPool.push(i as CardNumber);
+      }
+
+      let bestCard = hand[0];
+      let bestPenalty = Infinity;
+
+      for (const myCard of hand) {
+        let totalPenalty = 0;
+
+        for (let sample = 0; sample < K; sample++) {
+          // Shuffle unknown pool and deal to opponents
+          fisherYates(unknownPool, rng);
+
+          const plays: { card: CardNumber; isMe: boolean }[] = [
+            { card: myCard, isMe: true },
+          ];
+
+          let offset = 0;
+          for (let opp = 0; opp < opponentCount; opp++) {
+            const handSize = Math.min(cardsPerPlayer, unknownPool.length - offset);
+            if (handSize > 0) {
+              // Pick a random card from this opponent's dealt hand
+              const oppCardIdx = offset + Math.floor(rng() * handSize);
+              plays.push({ card: unknownPool[oppCardIdx], isMe: false });
+              offset += handSize;
+            }
+          }
+
+          const boardCopy = cloneBoard(board);
+          totalPenalty += simulateTurn(plays, boardCopy);
+        }
+
+        const avgPenalty = totalPenalty / K;
+        if (avgPenalty < bestPenalty) {
+          bestPenalty = avgPenalty;
+          bestCard = myCard;
+        }
+      }
+
+      return bestCard;
+    },
+
+    chooseRow(state) {
+      return fewestHeadsRowIndex(state.board.rows);
+    },
+  };
+}

--- a/src/engine/strategies/dummy.ts
+++ b/src/engine/strategies/dummy.ts
@@ -1,0 +1,46 @@
+import type { Strategy } from './types';
+import { cattleHeads } from '../card';
+
+function fewestHeadsRow(board: { rows: readonly (readonly number[])[] }): 0 | 1 | 2 | 3 {
+  let best = 0;
+  let bestP = Infinity;
+  for (let i = 0; i < board.rows.length; i++) {
+    const p = board.rows[i].reduce((s, c) => s + cattleHeads(c), 0);
+    if (p < bestP) { bestP = p; best = i; }
+  }
+  return best as 0 | 1 | 2 | 3;
+}
+
+/** Always plays the lowest card in hand. */
+export function createDummyMinStrategy(): Strategy {
+  return {
+    name: 'dummy-min',
+    chooseCard(state) {
+      let min = state.hand[0];
+      for (let i = 1; i < state.hand.length; i++) {
+        if (state.hand[i] < min) min = state.hand[i];
+      }
+      return min;
+    },
+    chooseRow(state) {
+      return fewestHeadsRow(state.board);
+    },
+  };
+}
+
+/** Always plays the highest card in hand. */
+export function createDummyMaxStrategy(): Strategy {
+  return {
+    name: 'dummy-max',
+    chooseCard(state) {
+      let max = state.hand[0];
+      for (let i = 1; i < state.hand.length; i++) {
+        if (state.hand[i] > max) max = state.hand[i];
+      }
+      return max;
+    },
+    chooseRow(state) {
+      return fewestHeadsRow(state.board);
+    },
+  };
+}

--- a/src/engine/strategies/index.ts
+++ b/src/engine/strategies/index.ts
@@ -1,6 +1,7 @@
 import type { Strategy } from './types';
 import { createRandomStrategy } from './random';
 import { createDummyMinStrategy, createDummyMaxStrategy } from './dummy';
+import { createBayesianSimpleStrategy } from './bayesian';
 
 export type { Strategy, TurnResolution } from './types';
 
@@ -9,4 +10,5 @@ export const strategies: ReadonlyMap<string, () => Strategy> = new Map([
   ['random', createRandomStrategy],
   ['dummy-min', createDummyMinStrategy],
   ['dummy-max', createDummyMaxStrategy],
+  ['bayesian-simple', createBayesianSimpleStrategy],
 ]);

--- a/src/engine/strategies/index.ts
+++ b/src/engine/strategies/index.ts
@@ -1,9 +1,12 @@
 import type { Strategy } from './types';
 import { createRandomStrategy } from './random';
+import { createDummyMinStrategy, createDummyMaxStrategy } from './dummy';
 
 export type { Strategy, TurnResolution } from './types';
 
 /** Registry mapping strategy names to factory functions. */
 export const strategies: ReadonlyMap<string, () => Strategy> = new Map([
   ['random', createRandomStrategy],
+  ['dummy-min', createDummyMinStrategy],
+  ['dummy-max', createDummyMaxStrategy],
 ]);


### PR DESCRIPTION
Adds dummy-min, dummy-max, and bayesian-simple strategies with specs and benchmark results. bayesian-simple achieves 3.2x relative win rate over random at 5-6 players. Also adds data-capture spec for future live game logging.