### PR TITLE
feat: MCS strategy with configurable simulation budget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ vite.config.ts.timestamp-*
 .vite/
 
 tmp/
+.playwright-mcp/
+*.png

--- a/project/results/mcs.md
+++ b/project/results/mcs.md
@@ -1,0 +1,104 @@
+# MCS (Monte-Carlo Search) Strategy Benchmark Results
+
+**Date:** 2026-04-28
+**Games per config:** 100
+**Strategy:** mcs (full-round Monte-Carlo search, configurable `mcPerCard` and `mcMax`)
+**Source:** Adapted from Brehmer & Gutsche's [rl-6-nimmt](https://github.com/johannbrehmer/rl-6nimmt)
+
+---
+
+## Configuration
+
+MCS has two key parameters:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `mcPerCard` | Simulations per candidate card | 50 |
+| `mcMax` | Total simulation cap across all cards | 500 |
+
+Effective sims/card = `min(mcMax / hand.length, mcPerCard)`. With 10 cards in hand at round start: `min(500/10, 50) = 50` sims per card.
+
+---
+
+## MCS parameter sweep vs 3×random (4 players, 100 games, seed: bench-mcs-params)
+
+Setup: 1×MCS + 3×random
+
+| mcPerCard | mcMax | Win Rate | Avg Score | Time/game | Time/move (est) |
+|-----------|-------|----------|-----------|-----------|-----------------|
+| 10 | 100 | 64.0% | 37.3 | 57ms | ~6ms |
+| 20 | 200 | 74.0% | 30.2 | 108ms | ~11ms |
+| **50** | **500** | **82.0%** | **27.5** | **270ms** | **~27ms** |
+
+**Comparison baseline (same setup, same seed):**
+
+| Strategy | Win Rate | Avg Score | Time/game |
+|----------|----------|-----------|-----------|
+| bayesian-simple (K=200) | 70.0% | 32.5 | 567ms |
+
+**Key takeaway:** MCS@50 beats bayesian's win rate (82% vs 70%) at half the wall-clock cost (270ms vs 567ms).
+
+---
+
+## MCS vs bayesian-simple head-to-head (4 players, 100 games, seed: bench-mcs-vs-bayes)
+
+Setup: 1×MCS + 1×bayesian-simple + 2×random
+
+| MCS Config | MCS Win Rate | Bayes Win Rate | MCS Avg Score | Bayes Avg Score | Time/game |
+|------------|--------------|----------------|---------------|-----------------|-----------|
+| mcPerCard=10, mcMax=100 | 40.0% | 56.0% | 37.0 | 33.6 | 638ms |
+| mcPerCard=20, mcMax=200 | 61.0% | 32.0% | 30.2 | 36.3 | 803ms |
+| **mcPerCard=50, mcMax=500** | **75.0%** | **25.0%** | **24.9** | **36.8** | **816ms** |
+
+**Key takeaway:** With adequate budget, MCS dominates bayesian 3:1 in direct competition.
+
+---
+
+## Analysis
+
+### Why simulation count matters so much
+
+MCS simulates the **entire remaining round** (all future turns) with randomly sampled opponent hands. With only 10 sims/card, the variance of multi-turn outcomes makes estimates extremely noisy. At 50 sims/card, the law of large numbers kicks in and the multi-turn lookahead becomes an advantage rather than a liability.
+
+### MCS vs Bayesian: architectural comparison
+
+| Dimension | MCS (mcPerCard=50) | bayesian-simple (K=200) |
+|-----------|--------------------|-------------------------|
+| Lookahead depth | Full round (all remaining turns) | 1 turn only |
+| Samples per card | 50 | 200 |
+| Total evaluations | ~500 full-round sims | ~2000 single-turn sims |
+| Opponent model | Random play | Random play |
+| Time per game (vs random) | 270ms | 567ms |
+| Win rate vs random (4p) | 82% | 70% |
+
+The deeper lookahead of MCS is worth more than the higher sample count of bayesian. MCS can anticipate multi-turn cascading penalties (e.g., playing a card now that sets up a bad position 3 turns later).
+
+### Performance scaling
+
+Time complexity per move: `O(mcPerCard × hand.length × turnsRemaining × playerCount)`
+
+At `mcPerCard=50` with a full hand (10 cards), early-round moves take ~27ms. Later moves are cheaper as hand shrinks and fewer turns remain to simulate.
+
+---
+
+## Recommended production config
+
+```
+mcs:mcPerCard=50,mcMax=500
+```
+
+This provides the best balance of strength and speed. For time-critical scenarios (e.g., BGA with sub-second response requirement), this is well within budget at ~27ms per decision.
+
+For maximum strength with no time constraint:
+```
+mcs:mcPerCard=100,mcMax=1000
+```
+
+---
+
+## Future work
+
+- **Higher budgets:** Test mcPerCard=100, 200 to find diminishing returns curve
+- **Hybrid playout policy:** Use bayesian scoring inside MCS simulations instead of random play
+- **Player count scaling:** Benchmark at 2-10 players (more players = more uncertainty = may need higher budget)
+- **Head-to-head at higher game counts:** Run 1000+ games for tighter confidence intervals

--- a/spec/strategies/mcs.md
+++ b/spec/strategies/mcs.md
@@ -1,10 +1,10 @@
-# Monte-Carlo Tree Search (MCTS) Strategy for 6 Nimmt!
+# Monte-Carlo Search (MCS) Strategy for 6 Nimmt!
 
 ## Overview
 
-A Monte-Carlo Tree Search strategy that simulates playout games from the current position to evaluate each possible card play. Inspired by AlphaZero's approach ("Alpha0.5" in the rl-6-nimmt reference implementation), adapted for 6 Nimmt!'s incomplete information setting.
+A Monte-Carlo Search strategy that simulates playout games from the current position to evaluate each possible card play. Inspired by AlphaZero's approach ("Alpha0.5" in the rl-6-nimmt reference implementation), adapted for 6 Nimmt!'s incomplete information setting.
 
-**Key insight:** Unlike perfect-information games (chess, Go), 6 Nimmt! has hidden information (opponents' hands are unknown). MCTS handles this by **sampling possible opponent hands** from the remaining card pool and simulating games against those sampled hands. Over many simulations, this produces robust move evaluations that account for uncertainty.
+**Key insight:** Unlike perfect-information games (chess, Go), 6 Nimmt! has hidden information (opponents' hands are unknown). MCS handles this by **sampling possible opponent hands** from the remaining card pool and simulating games against those sampled hands. Over many simulations, this produces robust move evaluations that account for uncertainty.
 
 **Reference:** Johann Brehmer & Marcel Gutsche, "Beating 6 nimmt! with reinforcement learning" ([rl-6-nimmt](https://github.com/johannbrehmer/rl-6nimmt)). Their Alpha0.5 agent achieved a 42% win rate and ELO 1806, beating Monte-Carlo search (40%), ACER (18%), D3QN (17%), and Random (19%). It also beat a strong human player 3-2 in a 5-game match.
 
@@ -159,8 +159,8 @@ function recommendCard(hand: number[], board: Board, availableCards: number[], p
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `mcPerCard` | 10 | Simulations per factorial of legal actions |
-| `mcMax` | 100 | Maximum total simulations (cap for large hands) |
+| `mcPerCard` | 50 | Simulations per candidate card |
+| `mcMax` | 500 | Maximum total simulations (cap for large hands) |
 | `cPuct` | 2.0 | PUCT exploration constant (Alpha0.5 variant only) |
 | `simulationPolicy` | `"random"` | Policy for simulated moves: `"random"` (MCS) or `"neural"` (Alpha0.5) |
 
@@ -169,15 +169,15 @@ function recommendCard(hand: number[], board: Board, availableCards: number[], p
 The number of simulations scales with hand size:
 
 ```
-n_simulations = min(mcMax, mcPerCard × handSize!)
+n_simulations = min(mcMax, mcPerCard × hand.length)
 ```
 
-| Cards in hand | Factorial | Actual sims (mcMax=100) |
-|--------------|-----------|-------------------------|
-| 10 | 3,628,800 | 100 |
-| 5 | 120 | 100 |
-| 3 | 6 | 60 |
-| 2 | 2 | 20 |
+| Cards in hand | Actual sims (mcMax=500) |
+|--------------|-------------------------|
+| 10 | 500 |
+| 5 | 250 |
+| 3 | 150 |
+| 2 | 100 |
 | 1 | 1 | (no choice) |
 
 For turn 1 with 10 cards, we always hit the cap. This means each card gets ~10 simulations — enough for a decent estimate.
@@ -212,9 +212,9 @@ If time-constrained, fall back to **greedy minimum:** pick the row with fewest c
 | **Computation** | O(hand × rows) | O(simulations × turns × players) |
 | **Accuracy** | Approximate (independence assumptions) | Converges to true value with more sims |
 | **Row interactions** | Limited (one-step lookahead) | Full (simulates to round-end) |
-| **Speed** | Very fast (<1ms) | Slower (10-100ms for 100 sims) |
+| **Speed** | Very fast (<1ms) | ~27ms per decision (500 sims) |
 
-**Key advantage of MCTS:** It naturally captures **multi-turn interactions** — the penalty of a card isn't just about this turn, but how it affects the board for future turns. Bayesian only does one-step lookahead.
+**Key advantage of MCS:** It naturally captures **multi-turn interactions** — the penalty of a card isn't just about this turn, but how it affects the board for future turns. Bayesian only does one-step lookahead.
 
 ---
 
@@ -222,7 +222,7 @@ If time-constrained, fall back to **greedy minimum:** pick the row with fewest c
 
 ### Integration with Our Engine
 
-The MCTS strategy needs:
+The MCS strategy needs:
 1. **Game simulation capability** — ability to play out a round from any state (already have this in our engine)
 2. **Card tracking** — available card pool (already maintained in session via `turnHistory`)
 3. **Time budget** — configurable max simulations to meet BGA time constraints (~5-15s per turn)
@@ -230,9 +230,9 @@ The MCTS strategy needs:
 ### Performance Considerations
 
 For live BGA play (5-15 second decision window):
-- 100 simulations × 9 remaining turns × 6 players = ~5,400 game steps per decision
-- Each game step is trivial (card placement + comparison) — should be <1ms
-- **Total estimated time:** 50-200ms for 100 simulations — well within budget
+- 500 simulations × 9 remaining turns × 4 players = ~18,000 game steps per decision
+- Each game step is trivial (card placement + comparison) — should be <0.01ms
+- **Measured time:** ~270ms per game (~27ms per decision) — well within budget
 
 ### Progressive Enhancement Path
 

--- a/spec/strategies/mcts.md
+++ b/spec/strategies/mcts.md
@@ -267,4 +267,17 @@ Based on the reference implementation's tournament results:
 | MCS (random playouts) | ~40% | 1745 |
 | Alpha0.5 (PUCT + neural) | ~42% | 1806 |
 
-Even the simplest MCS variant (Phase 1) should roughly **double** our win rate compared to random play. The 2% additional improvement from neural PUCT is marginal but measurable over many games.
+### Our Benchmark Results (200 games, 4 players, seed: bench3)
+
+| Strategy | Win Rate | Avg Score |
+|----------|----------|-----------|
+| **bayesian-simple** | **53.0%** | **35.4** |
+| mcs | 35.5% | 38.5 |
+| random (pooled ×2) | 6.0% | 61.8 |
+
+**Conclusion:** In our implementation, bayesian-simple outperforms MCS. The likely cause is simulation budget: MCS uses only ~10 simulations per card (capped at 100 total), producing noisy multi-turn estimates. Bayesian uses 200 samples for single-turn evaluation, yielding more reliable immediate decisions. The multi-turn lookahead advantage of MCS doesn't compensate for the higher variance from fewer samples.
+
+**Potential improvements:**
+- Increase simulation budget (500-1000) at the cost of latency
+- Hybrid: use bayesian scoring for simulated opponent moves (instead of random)
+- Use bayesian as first-turn evaluator, MCS for later turns when fewer cards remain

--- a/spec/strategies/mcts.md
+++ b/spec/strategies/mcts.md
@@ -1,0 +1,270 @@
+# Monte-Carlo Tree Search (MCTS) Strategy for 6 Nimmt!
+
+## Overview
+
+A Monte-Carlo Tree Search strategy that simulates playout games from the current position to evaluate each possible card play. Inspired by AlphaZero's approach ("Alpha0.5" in the rl-6-nimmt reference implementation), adapted for 6 Nimmt!'s incomplete information setting.
+
+**Key insight:** Unlike perfect-information games (chess, Go), 6 Nimmt! has hidden information (opponents' hands are unknown). MCTS handles this by **sampling possible opponent hands** from the remaining card pool and simulating games against those sampled hands. Over many simulations, this produces robust move evaluations that account for uncertainty.
+
+**Reference:** Johann Brehmer & Marcel Gutsche, "Beating 6 nimmt! with reinforcement learning" ([rl-6-nimmt](https://github.com/johannbrehmer/rl-6nimmt)). Their Alpha0.5 agent achieved a 42% win rate and ELO 1806, beating Monte-Carlo search (40%), ACER (18%), D3QN (17%), and Random (19%). It also beat a strong human player 3-2 in a 5-game match.
+
+---
+
+## Algorithm
+
+### High-Level Flow
+
+```
+For each legal card in hand:
+  Repeat N simulations:
+    1. Sample opponent hands from unknown card pool
+    2. Simulate game from current state to round-end
+    3. Record our penalty score from the simulation
+  Compute average penalty for this card
+Choose card with lowest average penalty (least expected damage)
+```
+
+### Detailed Steps
+
+#### 1. Card Memory (Information Tracking)
+
+Maintain a set of **available cards** — cards that could be in opponents' hands:
+
+```
+availableCards = {1..104}
+  - remove: my hand (known)
+  - remove: board cards (visible)
+  - remove: all previously played cards (observed in turn resolution)
+```
+
+At turn T in a round with N players:
+- My hand has `10 - (T-1)` cards remaining
+- Each opponent also has `10 - (T-1)` cards remaining
+- `availableCards` contains exactly `(N-1) × (10 - T + 1)` cards (opponents' remaining hands)
+
+#### 2. Sampling Opponent Hands (Information Set Sampling)
+
+For each simulation, create a "determinized" game state:
+
+```
+shuffle(availableCards)
+for each opponent i (1..N-1):
+  opponent_hand[i] = availableCards[i*handSize .. (i+1)*handSize - 1]
+  sort(opponent_hand[i])  // hands are always sorted
+```
+
+This is called **determinization** — we replace uncertainty with a concrete sample. Over many samples, this converges to the true expected value.
+
+#### 3. Playout Simulation
+
+From the sampled state, simulate the remainder of the round:
+
+```
+for each remaining turn:
+  for each player:
+    choose_action(player_hand, board)  → played_card
+  resolve_turn(played_cards, board)  → penalties
+  accumulate our_penalty
+return total our_penalty for this round
+```
+
+#### 4. Action Selection During Playout
+
+During simulation, players need a policy to select cards. Three options with increasing sophistication:
+
+| Variant | Opponent Policy | Our Policy | Complexity |
+|---------|----------------|------------|------------|
+| **MCS** (pure random) | Random | Random (after first move) | Low |
+| **PolicyMCS** | Neural network | Neural network | Medium |
+| **PUCT** (Alpha0.5) | Neural network | PUCT formula | High |
+
+**PUCT formula** (used for our first-move selection during simulation):
+
+```
+PUCT(a) = Q(a) + c_puct × P(a) × sqrt(N_total) / (1 + N(a))
+
+where:
+  Q(a) = normalized average return when action a was chosen (0 to 1)
+  P(a) = prior probability from neural policy network
+  c_puct = exploration constant (default 2.0)
+  N(a) = number of times action a has been simulated so far
+  N_total = total simulations so far
+```
+
+This balances exploitation (high Q) with exploration (high prior, low visit count).
+
+#### 5. Final Decision
+
+After all simulations complete, choose the card with **highest mean return** (least penalty):
+
+```
+best_card = argmax over legal_cards of mean(simulated_returns[card])
+```
+
+---
+
+## Simplification: MCS Variant (No Neural Network)
+
+For our initial implementation, we can use the **MCS variant** which requires no trained neural network:
+
+- All simulated moves (both ours and opponents) are **uniformly random**
+- Only the **first move** is varied systematically (one per legal action)
+- Still achieves 40% win rate (ELO 1745) — strong enough to beat RL agents
+
+### MCS Algorithm (Simplified)
+
+```typescript
+function recommendCard(hand: number[], board: Board, availableCards: number[], playerCount: number): number {
+  const results: Map<number, number[]> = new Map();
+  
+  for (const card of hand) {
+    results.set(card, []);
+  }
+  
+  const nSimulations = Math.min(MAX_SIMS, SIMS_PER_CARD * factorial(hand.length));
+  
+  for (let sim = 0; sim < nSimulations; sim++) {
+    // Sample opponent hands
+    const opponentHands = sampleOpponentHands(availableCards, hand.length, playerCount - 1);
+    
+    // Create simulated game from current board state
+    const simGame = createSimulation(board, hand, opponentHands);
+    
+    // Play out the round with random moves for everyone
+    // But our first move is sampled proportionally or round-robin
+    const firstCard = hand[sim % hand.length]; // or sample
+    const penalty = playOutRound(simGame, firstCard);
+    
+    results.get(firstCard)!.push(penalty);
+  }
+  
+  // Choose card with lowest average penalty
+  let bestCard = hand[0];
+  let bestMean = Infinity;
+  for (const [card, penalties] of results) {
+    const mean = penalties.reduce((a, b) => a + b, 0) / penalties.length;
+    if (mean < bestMean) {
+      bestMean = mean;
+      bestCard = card;
+    }
+  }
+  
+  return bestCard;
+}
+```
+
+---
+
+## Configuration Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `mcPerCard` | 10 | Simulations per factorial of legal actions |
+| `mcMax` | 100 | Maximum total simulations (cap for large hands) |
+| `cPuct` | 2.0 | PUCT exploration constant (Alpha0.5 variant only) |
+| `simulationPolicy` | `"random"` | Policy for simulated moves: `"random"` (MCS) or `"neural"` (Alpha0.5) |
+
+### Simulation Budget
+
+The number of simulations scales with hand size:
+
+```
+n_simulations = min(mcMax, mcPerCard × handSize!)
+```
+
+| Cards in hand | Factorial | Actual sims (mcMax=100) |
+|--------------|-----------|-------------------------|
+| 10 | 3,628,800 | 100 |
+| 5 | 120 | 100 |
+| 3 | 6 | 60 |
+| 2 | 2 | 20 |
+| 1 | 1 | (no choice) |
+
+For turn 1 with 10 cards, we always hit the cap. This means each card gets ~10 simulations — enough for a decent estimate.
+
+---
+
+## Row Pick Decision
+
+When forced to take a row (our card is lower than all row endings):
+
+```
+for each row (0..3):
+  Simulate taking that row:
+    - Penalty = sum of cattle heads in that row
+    - Board state after = row replaced with our card
+  Run MCS from resulting position for remaining turns
+  
+Choose row with lowest total expected penalty (immediate + future)
+```
+
+If time-constrained, fall back to **greedy minimum:** pick the row with fewest cattle heads.
+
+---
+
+## Comparison with Bayesian Strategy
+
+| Aspect | Bayesian | MCTS |
+|--------|----------|------|
+| **Approach** | Analytical (expected value) | Empirical (simulation) |
+| **Card probabilities** | Explicit belief distribution | Implicit via sampling |
+| **Opponent modeling** | Assumes uniform random | Samples hands, plays them out |
+| **Computation** | O(hand × rows) | O(simulations × turns × players) |
+| **Accuracy** | Approximate (independence assumptions) | Converges to true value with more sims |
+| **Row interactions** | Limited (one-step lookahead) | Full (simulates to round-end) |
+| **Speed** | Very fast (<1ms) | Slower (10-100ms for 100 sims) |
+
+**Key advantage of MCTS:** It naturally captures **multi-turn interactions** — the penalty of a card isn't just about this turn, but how it affects the board for future turns. Bayesian only does one-step lookahead.
+
+---
+
+## Implementation Notes
+
+### Integration with Our Engine
+
+The MCTS strategy needs:
+1. **Game simulation capability** — ability to play out a round from any state (already have this in our engine)
+2. **Card tracking** — available card pool (already maintained in session via `turnHistory`)
+3. **Time budget** — configurable max simulations to meet BGA time constraints (~5-15s per turn)
+
+### Performance Considerations
+
+For live BGA play (5-15 second decision window):
+- 100 simulations × 9 remaining turns × 6 players = ~5,400 game steps per decision
+- Each game step is trivial (card placement + comparison) — should be <1ms
+- **Total estimated time:** 50-200ms for 100 simulations — well within budget
+
+### Progressive Enhancement Path
+
+1. **Phase 1: MCS** (random playouts) — no ML, deterministic, easy to test
+2. **Phase 2: Heuristic policy** — use Bayesian scores as priors instead of uniform random
+3. **Phase 3: PUCT** — trained neural policy for tree guidance (requires training infrastructure)
+
+---
+
+## Interaction with Session State
+
+The MCTS strategy benefits greatly from **session state** (unlike one-shot recommendations):
+
+- **Card memory** accumulates over the round as cards are revealed
+- **Opponent play history** can inform a non-uniform opponent model (Phase 2+)
+- **Running penalty totals** help evaluate row-take vs risk-taking decisions
+
+Session events used:
+- `round_started` → initialize card pool (104 - hand - board starters)
+- `turn_resolved` → remove played cards from pool, update opponent model
+- `session_recommend` → run MCTS with current state
+
+---
+
+## Expected Performance
+
+Based on the reference implementation's tournament results:
+
+| Variant | Expected Win Rate (4 players) | ELO |
+|---------|-------------------------------|-----|
+| Random baseline | ~19% | 1556 |
+| MCS (random playouts) | ~40% | 1745 |
+| Alpha0.5 (PUCT + neural) | ~42% | 1806 |
+
+Even the simplest MCS variant (Phase 1) should roughly **double** our win rate compared to random play. The 2% additional improvement from neural PUCT is marginal but measurable over many games.

--- a/spec/strategies/mcts.md
+++ b/spec/strategies/mcts.md
@@ -267,17 +267,30 @@ Based on the reference implementation's tournament results:
 | MCS (random playouts) | ~40% | 1745 |
 | Alpha0.5 (PUCT + neural) | ~42% | 1806 |
 
-### Our Benchmark Results (200 games, 4 players, seed: bench3)
+### Our Benchmark Results
 
-| Strategy | Win Rate | Avg Score |
-|----------|----------|-----------|
-| **bayesian-simple** | **53.0%** | **35.4** |
-| mcs | 35.5% | 38.5 |
-| random (pooled ×2) | 6.0% | 61.8 |
+#### MCS vs Random (100 games, 4 players, seed: bench-mcs-params)
 
-**Conclusion:** In our implementation, bayesian-simple outperforms MCS. The likely cause is simulation budget: MCS uses only ~10 simulations per card (capped at 100 total), producing noisy multi-turn estimates. Bayesian uses 200 samples for single-turn evaluation, yielding more reliable immediate decisions. The multi-turn lookahead advantage of MCS doesn't compensate for the higher variance from fewer samples.
+| Strategy | mcPerCard | mcMax | Win Rate | Avg Score | Time/game |
+|----------|-----------|-------|----------|-----------|-----------|
+| mcs | 10 (default) | 100 | 64.0% | 37.3 | 57ms |
+| mcs | 20 | 200 | 74.0% | 30.2 | 108ms |
+| mcs | **50** | **500** | **82.0%** | **27.5** | **270ms** |
+| bayesian-simple | K=200 | — | 70.0% | 32.5 | 567ms |
 
-**Potential improvements:**
-- Increase simulation budget (500-1000) at the cost of latency
-- Hybrid: use bayesian scoring for simulated opponent moves (instead of random)
-- Use bayesian as first-turn evaluator, MCS for later turns when fewer cards remain
+#### MCS vs Bayesian head-to-head (100 games, 4 players, seed: bench-mcs-vs-bayes)
+
+Each game: 1×MCS + 1×bayesian-simple + 2×random
+
+| MCS Config | MCS Win | Bayes Win | MCS Score | Bayes Score | Time/game |
+|------------|---------|-----------|-----------|-------------|-----------|
+| mcPerCard=10 (default) | 40.0% | 56.0% | 37.0 | 33.6 | 638ms |
+| mcPerCard=20 | **61.0%** | 32.0% | 30.2 | 36.3 | 803ms |
+| mcPerCard=50 | **75.0%** | 25.0% | **24.9** | 36.8 | 816ms |
+
+**Conclusions:**
+
+1. **MCS with adequate budget dominates bayesian.** At `mcPerCard=50`, MCS beats bayesian 3:1 in direct competition.
+2. **MCS is more efficient.** Against random, MCS@50 achieves 82% win rate in 270ms/game vs bayesian's 70% in 567ms — better results at half the cost.
+3. **The default budget (10) is too low.** This confirms the reference implementation's finding that simulation count is the key tuning parameter.
+4. **Recommended production config:** `mcPerCard=50, mcMax=500` — best win rate at acceptable latency (~27ms per move decision).

--- a/src/cli/commands/play.ts
+++ b/src/cli/commands/play.ts
@@ -10,6 +10,7 @@ import {
   isGameOver,
   toCardChoiceState,
   strategies,
+  parseStrategySpec,
   cattleHeads,
   deriveSeedState,
   xoshiro256ss,
@@ -97,32 +98,33 @@ export const playCommand = new Command('play')
     const startTime = Date.now();
 
     // Parse strategies
-    let strategyNames: string[];
+    let strategySpecs: { name: string; options?: Record<string, unknown> }[];
     try {
-      strategyNames = parseStrategies(opts.strategies as string);
+      const names = parseStrategies(opts.strategies as string);
+      strategySpecs = names.map(parseStrategySpec);
     } catch {
       outputError(fmt, 'INVALID_STRATEGY', `Failed to parse strategies: ${opts.strategies}`);
       process.exit(1);
     }
 
     // Validate strategies exist
-    for (const name of strategyNames) {
-      if (!strategies.has(name)) {
+    for (const spec of strategySpecs) {
+      if (!strategies.has(spec.name)) {
         const valid = [...strategies.keys()];
-        const suggestion = didYouMean(name, valid);
+        const suggestion = didYouMean(spec.name, valid);
         outputError(fmt, 'INVALID_STRATEGY',
-          `Unknown strategy '${name}'.${suggestion ? ` Did you mean '${suggestion}'?` : ''}`, valid);
+          `Unknown strategy '${spec.name}'.${suggestion ? ` Did you mean '${suggestion}'?` : ''}`, valid);
         process.exit(1);
       }
     }
 
-    if (strategyNames.length < 2 || strategyNames.length > 10) {
-      outputError(fmt, 'INVALID_PLAYER_COUNT', `Need 2–10 strategies, got ${strategyNames.length}.`);
+    if (strategySpecs.length < 2 || strategySpecs.length > 10) {
+      outputError(fmt, 'INVALID_PLAYER_COUNT', `Need 2–10 strategies, got ${strategySpecs.length}.`);
       process.exit(1);
     }
 
     const seed = opts.seed ?? randomUUID();
-    const players = strategyNames.map((s, i) => ({ id: `player-${i}`, strategy: s }));
+    const players = strategySpecs.map((s, i) => ({ id: `player-${i}`, strategy: s.name, options: s.options }));
     const playerIds = players.map((p) => p.id);
 
     try {
@@ -131,7 +133,7 @@ export const playCommand = new Command('play')
       // Instantiate strategies
       const strategyMap = new Map<string, Strategy>();
       for (const p of players) {
-        strategyMap.set(p.id, strategies.get(p.strategy)!());
+        strategyMap.set(p.id, strategies.get(p.strategy)!(p.options));
       }
       for (const p of players) {
         strategyMap.get(p.id)!.onGameStart?.({
@@ -259,7 +261,7 @@ export const playCommand = new Command('play')
       const output: PlayResult = {
         meta: createMeta('play', startTime),
         seed,
-        strategies: strategyNames,
+        strategies: strategySpecs.map(s => s.name),
         rounds,
         finalResults,
       };

--- a/src/cli/commands/recommend.ts
+++ b/src/cli/commands/recommend.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { readFileSync } from 'node:fs';
 import type { CardChoiceState, RowChoiceState } from '../../engine/types.js';
 import type { TurnResolution } from '../../engine/strategies/types.js';
-import { strategies, deriveSeedState, xoshiro256ss } from '../../engine/index.js';
+import { strategies, parseStrategySpec, deriveSeedState, xoshiro256ss } from '../../engine/index.js';
 import { format } from '../formatters/index.js';
 import type { RecommendResult, OutputFormat } from '../formatters/types.js';
 import { didYouMean, outputError, createMeta } from '../helpers.js';
@@ -56,8 +56,9 @@ export const recommendCommand = new Command('recommend')
     const fmt = opts.format as OutputFormat;
     const startTime = Date.now();
 
-    // Validate strategy
-    const strategyName = opts.strategy as string;
+    // Validate strategy (supports name:key=val syntax)
+    const strategySpec = parseStrategySpec(opts.strategy as string);
+    const strategyName = strategySpec.name;
     if (!strategies.has(strategyName)) {
       const valid = [...strategies.keys()];
       const suggestion = didYouMean(strategyName, valid);
@@ -119,7 +120,7 @@ export const recommendCommand = new Command('recommend')
     const warnings = checkWarnings(state);
 
     // Instantiate strategy
-    const strat = strategies.get(strategyName)!();
+    const strat = strategies.get(strategyName)!(strategySpec.options);
     const playerCount = (state.playerCount as number) ?? 2;
     const seedStr = 'recommend-' + Date.now();
     const rngState = deriveSeedState(seedStr);

--- a/src/cli/commands/simulate.ts
+++ b/src/cli/commands/simulate.ts
@@ -147,7 +147,7 @@ export const simulateCommand = new Command('simulate')
       players: strategySpecs.map((s, i) => ({
         id: `player-${i}`,
         strategy: s.name,
-        ...(s.options ? { params: s.options } : {}),
+        ...(s.options ? { strategyOptions: s.options } : {}),
       })),
       seed,
     };

--- a/src/cli/commands/simulate.ts
+++ b/src/cli/commands/simulate.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { randomUUID } from 'node:crypto';
 import { runBatch } from '../../sim/index.js';
-import { strategies } from '../../engine/index.js';
+import { strategies, parseStrategySpec } from '../../engine/index.js';
 import { format } from '../formatters/index.js';
 import type { SimulateResult, StrategyResultRow, SeatResultRow, OutputFormat } from '../formatters/types.js';
 import { didYouMean, outputError, createMeta, parseStrategies } from '../helpers.js';
@@ -93,25 +93,26 @@ export const simulateCommand = new Command('simulate')
     const fmt = opts.format as OutputFormat;
     const startTime = Date.now();
 
-    // Parse strategies
-    let strategyNames: string[];
+    // Parse strategies (supports name:key=val,key=val syntax)
+    let strategySpecs: { name: string; options?: Record<string, unknown> }[];
     const raw = opts.strategies as string;
     try {
-      strategyNames = parseStrategies(raw);
+      const names = parseStrategies(raw);
+      strategySpecs = names.map(parseStrategySpec);
     } catch {
       outputError(fmt, 'INVALID_STRATEGY', `Failed to parse strategies: ${raw}`);
       process.exit(1);
     }
 
     // Validate strategies exist
-    for (const name of strategyNames) {
-      if (!strategies.has(name)) {
+    for (const spec of strategySpecs) {
+      if (!strategies.has(spec.name)) {
         const valid = [...strategies.keys()];
-        const suggestion = didYouMean(name, valid);
+        const suggestion = didYouMean(spec.name, valid);
         outputError(
           fmt,
           'INVALID_STRATEGY',
-          `Unknown strategy '${name}'.${suggestion ? ` Did you mean '${suggestion}'?` : ''}`,
+          `Unknown strategy '${spec.name}'.${suggestion ? ` Did you mean '${suggestion}'?` : ''}`,
           valid,
         );
         process.exit(1);
@@ -119,8 +120,8 @@ export const simulateCommand = new Command('simulate')
     }
 
     // Validate player count
-    if (strategyNames.length < 2 || strategyNames.length > 10) {
-      outputError(fmt, 'INVALID_PLAYER_COUNT', `Need 2–10 strategies, got ${strategyNames.length}.`, [
+    if (strategySpecs.length < 2 || strategySpecs.length > 10) {
+      outputError(fmt, 'INVALID_PLAYER_COUNT', `Need 2–10 strategies, got ${strategySpecs.length}.`, [
         'Provide 2 to 10 comma-separated strategy names',
       ]);
       process.exit(1);
@@ -137,13 +138,17 @@ export const simulateCommand = new Command('simulate')
 
     // Dry run
     if (opts.dryRun) {
-      console.log(JSON.stringify({ dryRun: true, strategies: strategyNames, games, seed, format: fmt }));
+      console.log(JSON.stringify({ dryRun: true, strategies: strategySpecs.map(s => s.name), games, seed, format: fmt }));
       return;
     }
 
     // Build SimConfig
     const config = {
-      players: strategyNames.map((s, i) => ({ id: `player-${i}`, strategy: s })),
+      players: strategySpecs.map((s, i) => ({
+        id: `player-${i}`,
+        strategy: s.name,
+        ...(s.options ? { params: s.options } : {}),
+      })),
       seed,
     };
 
@@ -154,7 +159,7 @@ export const simulateCommand = new Command('simulate')
       const output: SimulateResult = {
         meta: createMeta('simulate', startTime),
         gamesPlayed: result.gamesPlayed,
-        strategies: strategyNames,
+        strategies: strategySpecs.map(s => s.name),
         seed,
         results: buildResultRows(result, config),
         perSeat: buildSeatRows(result, config),

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -63,5 +63,17 @@ export function parseStrategies(raw: string): string[] {
   if (raw.startsWith('[')) {
     return JSON.parse(raw) as string[];
   }
-  return raw.split(',').map((s) => s.trim());
+  // Smart split: commas inside colon-params (key=val,key=val) should not be treated
+  // as strategy separators. A segment is a param continuation if it contains '='.
+  const parts = raw.split(',').map((s) => s.trim());
+  const result: string[] = [];
+  for (const part of parts) {
+    if (result.length > 0 && part.includes('=') && !part.includes(':')) {
+      // This is a param continuation of the previous strategy spec
+      result[result.length - 1] += ',' + part;
+    } else {
+      result.push(part);
+    }
+  }
+  return result;
 }

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -64,12 +64,16 @@ export function parseStrategies(raw: string): string[] {
     return JSON.parse(raw) as string[];
   }
   // Smart split: commas inside colon-params (key=val,key=val) should not be treated
-  // as strategy separators. A segment is a param continuation if it contains '='.
+  // as strategy separators. A segment is a param continuation only if it contains '='
+  // and the previous entry is a parameterized spec (contains ':').
+  // Flag-style params without '=' must use explicit '=true' syntax.
   const parts = raw.split(',').map((s) => s.trim());
   const result: string[] = [];
   for (const part of parts) {
-    if (result.length > 0 && part.includes('=') && !part.includes(':')) {
-      // This is a param continuation of the previous strategy spec
+    if (!part) continue;
+    const prevHasColon = result.length > 0 && result[result.length - 1].includes(':');
+    if (prevHasColon && part.includes('=') && !part.includes(':')) {
+      // Param continuation of previous strategy spec
       result[result.length - 1] += ',' + part;
     } else {
       result.push(part);

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -45,4 +45,4 @@ export {
 export { toCardChoiceState, toRowChoiceState } from './visible-state';
 
 export type { Strategy, TurnResolution } from './strategies';
-export { strategies } from './strategies';
+export { strategies, parseStrategySpec } from './strategies';

--- a/src/engine/strategies/index.ts
+++ b/src/engine/strategies/index.ts
@@ -2,6 +2,7 @@ import type { Strategy } from './types';
 import { createRandomStrategy } from './random';
 import { createDummyMinStrategy, createDummyMaxStrategy } from './dummy';
 import { createBayesianSimpleStrategy } from './bayesian';
+import { createMcsStrategy } from './mcs';
 
 export type { Strategy, TurnResolution } from './types';
 
@@ -11,4 +12,5 @@ export const strategies: ReadonlyMap<string, () => Strategy> = new Map([
   ['dummy-min', createDummyMinStrategy],
   ['dummy-max', createDummyMaxStrategy],
   ['bayesian-simple', createBayesianSimpleStrategy],
+  ['mcs', createMcsStrategy],
 ]);

--- a/src/engine/strategies/index.ts
+++ b/src/engine/strategies/index.ts
@@ -14,7 +14,7 @@ export const strategies: ReadonlyMap<string, StrategyFactory> = new Map([
   ['dummy-min', () => createDummyMinStrategy()],
   ['dummy-max', () => createDummyMaxStrategy()],
   ['bayesian-simple', () => createBayesianSimpleStrategy()],
-  ['mcs', (opts) => createMcsStrategy(opts as Parameters<typeof createMcsStrategy>[0])],
+  ['mcs', (opts?: Record<string, unknown>) => createMcsStrategy(opts as Parameters<typeof createMcsStrategy>[0])],
 ]);
 
 /**

--- a/src/engine/strategies/index.ts
+++ b/src/engine/strategies/index.ts
@@ -6,11 +6,43 @@ import { createMcsStrategy } from './mcs';
 
 export type { Strategy, TurnResolution } from './types';
 
+export type StrategyFactory = (opts?: Record<string, unknown>) => Strategy;
+
 /** Registry mapping strategy names to factory functions. */
-export const strategies: ReadonlyMap<string, () => Strategy> = new Map([
-  ['random', createRandomStrategy],
-  ['dummy-min', createDummyMinStrategy],
-  ['dummy-max', createDummyMaxStrategy],
-  ['bayesian-simple', createBayesianSimpleStrategy],
-  ['mcs', createMcsStrategy],
+export const strategies: ReadonlyMap<string, StrategyFactory> = new Map([
+  ['random', () => createRandomStrategy()],
+  ['dummy-min', () => createDummyMinStrategy()],
+  ['dummy-max', () => createDummyMaxStrategy()],
+  ['bayesian-simple', () => createBayesianSimpleStrategy()],
+  ['mcs', (opts) => createMcsStrategy(opts as Parameters<typeof createMcsStrategy>[0])],
 ]);
+
+/**
+ * Parse a strategy specifier string with optional colon-separated params.
+ * Examples:
+ *   "mcs" → { name: "mcs", options: undefined }
+ *   "mcs:mcMax=500,mcPerCard=50" → { name: "mcs", options: { mcMax: 500, mcPerCard: 50 } }
+ */
+export function parseStrategySpec(spec: string): { name: string; options?: Record<string, unknown> } {
+  const colonIdx = spec.indexOf(':');
+  if (colonIdx === -1) return { name: spec };
+
+  const name = spec.slice(0, colonIdx);
+  const paramStr = spec.slice(colonIdx + 1);
+  if (!paramStr) return { name };
+
+  const options: Record<string, unknown> = {};
+  for (const pair of paramStr.split(',')) {
+    const eqIdx = pair.indexOf('=');
+    if (eqIdx === -1) {
+      options[pair] = true;
+    } else {
+      const key = pair.slice(0, eqIdx);
+      const rawVal = pair.slice(eqIdx + 1);
+      // Attempt numeric coercion
+      const num = Number(rawVal);
+      options[key] = Number.isNaN(num) ? rawVal : num;
+    }
+  }
+  return { name, options };
+}

--- a/src/engine/strategies/index.ts
+++ b/src/engine/strategies/index.ts
@@ -27,18 +27,21 @@ export function parseStrategySpec(spec: string): { name: string; options?: Recor
   const colonIdx = spec.indexOf(':');
   if (colonIdx === -1) return { name: spec };
 
-  const name = spec.slice(0, colonIdx);
-  const paramStr = spec.slice(colonIdx + 1);
+  const name = spec.slice(0, colonIdx).trim();
+  const paramStr = spec.slice(colonIdx + 1).trim();
   if (!paramStr) return { name };
 
   const options: Record<string, unknown> = {};
-  for (const pair of paramStr.split(',')) {
+  for (const rawPair of paramStr.split(',')) {
+    const pair = rawPair.trim();
+    if (!pair) continue;
     const eqIdx = pair.indexOf('=');
     if (eqIdx === -1) {
+      // Bare flags treated as true
       options[pair] = true;
     } else {
-      const key = pair.slice(0, eqIdx);
-      const rawVal = pair.slice(eqIdx + 1);
+      const key = pair.slice(0, eqIdx).trim();
+      const rawVal = pair.slice(eqIdx + 1).trim();
       // Attempt numeric coercion
       const num = Number(rawVal);
       options[key] = Number.isNaN(num) ? rawVal : num;

--- a/src/engine/strategies/mcs.ts
+++ b/src/engine/strategies/mcs.ts
@@ -5,6 +5,13 @@ import { cattleHeads } from '../card';
 const DEFAULT_MC_MAX = 100;
 const DEFAULT_MC_PER_CARD = 10;
 
+export interface McsOptions {
+  /** Maximum total simulations across all cards (default: 100) */
+  mcMax?: number;
+  /** Simulations per candidate card (default: 10, capped by mcMax) */
+  mcPerCard?: number;
+}
+
 function fewestHeadsRowIndex(rows: readonly (readonly CardNumber[])[]): 0 | 1 | 2 | 3 {
   let best = 0;
   let bestP = Infinity;
@@ -143,7 +150,9 @@ function simulateRound(
  * The difference is likely due to low simulation budget (100 max) producing noisy
  * multi-turn estimates vs bayesian's focused single-turn evaluation (K=200 samples).
  */
-export function createMcsStrategy(): Strategy {
+export function createMcsStrategy(options: McsOptions = {}): Strategy {
+  const mcMax = options.mcMax ?? DEFAULT_MC_MAX;
+  const mcPerCard = options.mcPerCard ?? DEFAULT_MC_PER_CARD;
   let rng: () => number = Math.random;
   let playerCount = 2;
   let seenCards = new Set<number>();
@@ -188,7 +197,7 @@ export function createMcsStrategy(): Strategy {
       }
 
       // Number of simulations
-      const nSims = Math.min(DEFAULT_MC_MAX, DEFAULT_MC_PER_CARD * hand.length);
+      const nSims = Math.min(mcMax, mcPerCard * hand.length);
 
       // If only one card, just play it
       if (hand.length === 1) return hand[0];
@@ -265,7 +274,7 @@ export function createMcsStrategy(): Strategy {
         return fewestHeadsRowIndex(board.rows);
       }
 
-      const simsPerRow = 10;
+      const simsPerRow = mcPerCard;
       let bestRow: 0 | 1 | 2 | 3 = 0;
       let bestPenalty = Infinity;
 

--- a/src/engine/strategies/mcs.ts
+++ b/src/engine/strategies/mcs.ts
@@ -1,0 +1,330 @@
+import type { Strategy, TurnResolution } from './types';
+import type { CardNumber, Board } from '../types';
+import { cattleHeads } from '../card';
+
+const DEFAULT_MC_MAX = 100;
+const DEFAULT_MC_PER_CARD = 10;
+
+function fewestHeadsRowIndex(rows: readonly (readonly CardNumber[])[]): 0 | 1 | 2 | 3 {
+  let best = 0;
+  let bestP = Infinity;
+  for (let i = 0; i < rows.length; i++) {
+    const p = rows[i].reduce((s, c) => s + cattleHeads(c), 0);
+    if (p < bestP) {
+      bestP = p;
+      best = i;
+    }
+  }
+  return best as 0 | 1 | 2 | 3;
+}
+
+/** Deep-copy board rows into mutable arrays. */
+function cloneBoard(board: Board): CardNumber[][] {
+  return board.rows.map((row) => [...row]);
+}
+
+/** Fisher-Yates shuffle (in-place) using provided rng. */
+function fisherYates<T>(arr: T[], rng: () => number): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+  }
+  return arr;
+}
+
+/**
+ * Simulate placing all plays onto the board, return penalty for player 0 (us).
+ * Modifies board in-place.
+ */
+function simulateTurn(
+  plays: CardNumber[],
+  board: CardNumber[][],
+  myIndex: number,
+): number {
+  const indexed = plays.map((card, i) => ({ card, idx: i }));
+  indexed.sort((a, b) => a.card - b.card);
+  let penalty = 0;
+
+  for (const { card, idx } of indexed) {
+    let bestRow = -1;
+    let bestTail = -1;
+    for (let i = 0; i < board.length; i++) {
+      const tail = board[i][board[i].length - 1];
+      if (tail < card && tail > bestTail) {
+        bestTail = tail;
+        bestRow = i;
+      }
+    }
+
+    if (bestRow === -1) {
+      // Card lower than all tails — pick row with fewest heads
+      const rowIdx = fewestHeadsRowIndex(board);
+      if (idx === myIndex) {
+        penalty += board[rowIdx].reduce((s, c) => s + cattleHeads(c), 0);
+      }
+      board[rowIdx] = [card];
+    } else if (board[bestRow].length >= 5) {
+      // Overflow: 6th card
+      if (idx === myIndex) {
+        penalty += board[bestRow].reduce((s, c) => s + cattleHeads(c), 0);
+      }
+      board[bestRow] = [card];
+    } else {
+      board[bestRow].push(card);
+    }
+  }
+
+  return penalty;
+}
+
+/**
+ * Simulate the entire remaining round from a given state.
+ * Returns total penalty accumulated by "us" (player index 0).
+ *
+ * hands[0] = our hand (with myCard already chosen for turn 1)
+ * hands[1..N-1] = sampled opponent hands
+ */
+function simulateRound(
+  board: CardNumber[][],
+  hands: CardNumber[][],
+  myFirstCard: CardNumber,
+  rng: () => number,
+): number {
+  let totalPenalty = 0;
+  const playerCount = hands.length;
+
+  // First turn: we play myFirstCard, opponents play random
+  const firstPlays: CardNumber[] = [myFirstCard];
+  for (let i = 1; i < playerCount; i++) {
+    if (hands[i].length === 0) continue;
+    const idx = Math.floor(rng() * hands[i].length);
+    firstPlays.push(hands[i][idx]);
+    hands[i].splice(idx, 1);
+  }
+  // Remove our played card from hand
+  const myHandIdx = hands[0].indexOf(myFirstCard);
+  if (myHandIdx !== -1) hands[0].splice(myHandIdx, 1);
+
+  totalPenalty += simulateTurn(firstPlays, board, 0);
+
+  // Remaining turns: all players play random
+  const remainingTurns = hands[0].length;
+  for (let t = 0; t < remainingTurns; t++) {
+    const plays: CardNumber[] = [];
+    for (let i = 0; i < playerCount; i++) {
+      if (hands[i].length === 0) continue;
+      const idx = Math.floor(rng() * hands[i].length);
+      plays.push(hands[i][idx]);
+      hands[i].splice(idx, 1);
+    }
+    if (plays.length > 0) {
+      totalPenalty += simulateTurn(plays, board, 0);
+    }
+  }
+
+  return totalPenalty;
+}
+
+/**
+ * Monte-Carlo Search strategy.
+ *
+ * Simulates full remaining rounds with random opponent hands to evaluate
+ * each possible card play. Picks the card with lowest average total penalty
+ * across all simulations.
+ *
+ * Based on the MCS agent from:
+ *   Johann Brehmer & Marcel Gutsche, "Beating 6 nimmt! with reinforcement learning"
+ *   https://github.com/johannbrehmer/rl-6nimmt
+ *
+ * Their MCS achieved ~40% win rate (ELO 1745) in 4-player self-play tournaments.
+ * In our benchmarks (200 games, 4 players), MCS wins 35.5% vs bayesian-simple's 53%.
+ * The difference is likely due to low simulation budget (100 max) producing noisy
+ * multi-turn estimates vs bayesian's focused single-turn evaluation (K=200 samples).
+ */
+export function createMcsStrategy(): Strategy {
+  let rng: () => number = Math.random;
+  let playerCount = 2;
+  let seenCards = new Set<number>();
+
+  return {
+    name: 'mcs',
+
+    onGameStart(config) {
+      rng = config.rng;
+      playerCount = config.playerCount;
+      seenCards = new Set();
+    },
+
+    onTurnResolved(resolution: TurnResolution) {
+      for (const play of resolution.plays) {
+        seenCards.add(play.card);
+      }
+    },
+
+    chooseCard(state) {
+      const { hand, board, turn } = state;
+      const opponentCount = playerCount - 1;
+      const cardsPerPlayer = 10 - turn + 1; // cards remaining per hand (including this turn)
+
+      // Build unknown pool
+      const known = new Set<number>();
+      for (const c of hand) known.add(c);
+      for (const row of board.rows) {
+        for (const c of row) known.add(c);
+      }
+      for (const c of seenCards) known.add(c);
+      for (const entry of state.turnHistory) {
+        for (const play of entry.plays) known.add(play.card);
+      }
+      for (const row of state.initialBoardCards.rows) {
+        for (const c of row) known.add(c);
+      }
+
+      const unknownPool: CardNumber[] = [];
+      for (let i = 1; i <= 104; i++) {
+        if (!known.has(i)) unknownPool.push(i as CardNumber);
+      }
+
+      // Number of simulations
+      const nSims = Math.min(DEFAULT_MC_MAX, DEFAULT_MC_PER_CARD * hand.length);
+
+      // If only one card, just play it
+      if (hand.length === 1) return hand[0];
+
+      let bestCard = hand[0];
+      let bestPenalty = Infinity;
+
+      for (const myCard of hand) {
+        let totalPenalty = 0;
+        const simsPerCard = Math.max(1, Math.floor(nSims / hand.length));
+
+        for (let sample = 0; sample < simsPerCard; sample++) {
+          // Shuffle and deal opponent hands
+          fisherYates(unknownPool, rng);
+
+          const hands: CardNumber[][] = [];
+          // Our hand (remaining cards after playing myCard)
+          hands.push([...hand].filter((c) => c !== myCard) as CardNumber[]);
+
+          let offset = 0;
+          for (let opp = 0; opp < opponentCount; opp++) {
+            const handSize = Math.min(cardsPerPlayer, unknownPool.length - offset);
+            if (handSize > 0) {
+              hands.push(unknownPool.slice(offset, offset + handSize) as CardNumber[]);
+              offset += handSize;
+            } else {
+              hands.push([]);
+            }
+          }
+
+          const boardCopy = cloneBoard(board);
+          totalPenalty += simulateRound(boardCopy, hands, myCard, rng);
+        }
+
+        const avgPenalty = totalPenalty / simsPerCard;
+        if (avgPenalty < bestPenalty) {
+          bestPenalty = avgPenalty;
+          bestCard = myCard;
+        }
+      }
+
+      return bestCard;
+    },
+
+    chooseRow(state) {
+      // For row picks: simulate remaining round for each row choice
+      const { board, hand } = state;
+      const opponentCount = playerCount - 1;
+      const cardsPerPlayer = hand.length; // cards remaining after this turn resolves
+
+      // Build unknown pool
+      const known = new Set<number>();
+      for (const c of hand) known.add(c);
+      for (const row of board.rows) {
+        for (const c of row) known.add(c);
+      }
+      for (const c of seenCards) known.add(c);
+      for (const entry of state.turnHistory) {
+        for (const play of entry.plays) known.add(play.card);
+      }
+      // Also add cards revealed this turn
+      for (const play of state.revealedThisTurn) {
+        known.add(play.card);
+      }
+      known.add(state.triggeringCard);
+
+      const unknownPool: CardNumber[] = [];
+      for (let i = 1; i <= 104; i++) {
+        if (!known.has(i)) unknownPool.push(i as CardNumber);
+      }
+
+      // If cardsPerPlayer is 0 or this is the last turn, just pick fewest heads
+      if (cardsPerPlayer === 0) {
+        return fewestHeadsRowIndex(board.rows);
+      }
+
+      const simsPerRow = 10;
+      let bestRow: 0 | 1 | 2 | 3 = 0;
+      let bestPenalty = Infinity;
+
+      for (let rowIdx = 0; rowIdx < 4; rowIdx++) {
+        let totalPenalty = 0;
+
+        for (let sample = 0; sample < simsPerRow; sample++) {
+          // Simulate taking this row
+          const boardCopy = cloneBoard(board);
+          const rowPenalty = boardCopy[rowIdx].reduce((s, c) => s + cattleHeads(c), 0);
+          boardCopy[rowIdx] = [state.triggeringCard];
+
+          // If no cards remain, just evaluate immediate penalty
+          if (cardsPerPlayer === 0) {
+            totalPenalty += rowPenalty;
+            continue;
+          }
+
+          // Deal opponent hands for remaining turns
+          fisherYates(unknownPool, rng);
+          const hands: CardNumber[][] = [[...hand] as CardNumber[]];
+          let offset = 0;
+          for (let opp = 0; opp < opponentCount; opp++) {
+            const hs = Math.min(cardsPerPlayer, unknownPool.length - offset);
+            if (hs > 0) {
+              hands.push(unknownPool.slice(offset, offset + hs) as CardNumber[]);
+              offset += hs;
+            } else {
+              hands.push([]);
+            }
+          }
+
+          // Play out remaining turns randomly
+          let simPenalty = rowPenalty;
+          const remainingTurns = hands[0].length;
+          for (let t = 0; t < remainingTurns; t++) {
+            const plays: CardNumber[] = [];
+            for (let i = 0; i < hands.length; i++) {
+              if (hands[i].length === 0) continue;
+              const idx = Math.floor(rng() * hands[i].length);
+              plays.push(hands[i][idx]);
+              hands[i].splice(idx, 1);
+            }
+            if (plays.length > 0) {
+              simPenalty += simulateTurn(plays, boardCopy, 0);
+            }
+          }
+
+          totalPenalty += simPenalty;
+        }
+
+        const avgPenalty = totalPenalty / simsPerRow;
+        if (avgPenalty < bestPenalty) {
+          bestPenalty = avgPenalty;
+          bestRow = rowIdx as 0 | 1 | 2 | 3;
+        }
+      }
+
+      return bestRow;
+    },
+  };
+}

--- a/src/engine/strategies/mcs.ts
+++ b/src/engine/strategies/mcs.ts
@@ -2,13 +2,13 @@ import type { Strategy, TurnResolution } from './types';
 import type { CardNumber, Board } from '../types';
 import { cattleHeads } from '../card';
 
-const DEFAULT_MC_MAX = 100;
-const DEFAULT_MC_PER_CARD = 10;
+const DEFAULT_MC_MAX = 500;
+const DEFAULT_MC_PER_CARD = 50;
 
 export interface McsOptions {
-  /** Maximum total simulations across all cards (default: 100) */
+  /** Maximum total simulations across all cards (default: 500) */
   mcMax?: number;
-  /** Simulations per candidate card (default: 10, capped by mcMax) */
+  /** Simulations per candidate card (default: 50, capped by mcMax) */
   mcPerCard?: number;
 }
 

--- a/src/engine/strategies/mcs.ts
+++ b/src/engine/strategies/mcs.ts
@@ -146,13 +146,12 @@ function simulateRound(
  *   https://github.com/johannbrehmer/rl-6nimmt
  *
  * Their MCS achieved ~40% win rate (ELO 1745) in 4-player self-play tournaments.
- * In our benchmarks (200 games, 4 players), MCS wins 35.5% vs bayesian-simple's 53%.
- * The difference is likely due to low simulation budget (100 max) producing noisy
- * multi-turn estimates vs bayesian's focused single-turn evaluation (K=200 samples).
+ * With default config (mcPerCard=50, mcMax=500), our implementation achieves 82%
+ * win rate vs random and 75% vs bayesian-simple in 4-player games.
  */
 export function createMcsStrategy(options: McsOptions = {}): Strategy {
-  const mcMax = options.mcMax ?? DEFAULT_MC_MAX;
-  const mcPerCard = options.mcPerCard ?? DEFAULT_MC_PER_CARD;
+  const mcMax = Math.max(1, Math.floor(Number(options.mcMax) || DEFAULT_MC_MAX));
+  const mcPerCard = Math.max(1, Math.floor(Number(options.mcPerCard) || DEFAULT_MC_PER_CARD));
   let rng: () => number = Math.random;
   let playerCount = 2;
   let seenCards = new Set<number>();
@@ -244,9 +243,11 @@ export function createMcsStrategy(options: McsOptions = {}): Strategy {
 
     chooseRow(state) {
       // For row picks: simulate remaining round for each row choice
-      const { board, hand } = state;
+      const { board } = state;
       const opponentCount = playerCount - 1;
-      const cardsPerPlayer = hand.length; // cards remaining after this turn resolves
+      // Remove triggeringCard from hand — it's already been played this turn
+      const hand = state.hand.filter(c => c !== state.triggeringCard);
+      const cardsPerPlayer = hand.length;
 
       // Build unknown pool
       const known = new Set<number>();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -58,6 +58,7 @@ const TOOL_DEFINITIONS = [
       properties: {
         state: { type: 'object' as const, description: 'Game state for recommendation' },
         strategy: { type: 'string' as const, description: 'Strategy name to use' },
+        strategyOptions: { type: 'object' as const, description: 'Strategy-specific options (e.g. { mcMax: 500 } for mcs)' },
         decision: { type: 'string' as const, enum: ['card', 'row'], description: 'Decision type (auto-detected if omitted)' },
         timeout: { type: 'number' as const, description: 'Timeout in milliseconds' },
       },
@@ -75,6 +76,7 @@ const TOOL_DEFINITIONS = [
         playerId: { type: 'string' as const, description: 'Player ID for this session' },
         seatIndex: { type: 'number' as const, description: 'Seat index (optional)' },
         seed: { type: 'string' as const, description: 'RNG seed (optional)' },
+        strategyOptions: { type: 'object' as const, description: 'Strategy-specific options (e.g. { mcMax: 500, mcPerCard: 50 } for mcs)' },
       },
       required: ['strategy', 'playerCount', 'playerId'],
     },
@@ -252,6 +254,7 @@ export function createServer(config: ServerConfig = {}) {
         const result = recommendOnce({
           state: (args?.state as Record<string, unknown>) ?? {},
           strategy: (args?.strategy as string) ?? '',
+          strategyOptions: args?.strategyOptions as Record<string, unknown> | undefined,
           decision: args?.decision as 'card' | 'row' | undefined,
           timeout: args?.timeout as number | undefined,
         });

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -18,6 +18,7 @@ interface Session {
   id: string;
   strategy: Strategy;
   strategyName: string;
+  strategyOptions?: Record<string, unknown>;
   playerId: string;
   playerCount: number;
   seed: string;
@@ -130,8 +131,9 @@ export class SessionManager {
     playerId: string;
     seatIndex?: number;
     seed?: string;
+    strategyOptions?: Record<string, unknown>;
   }): object | DomainError {
-    const { strategy: strategyName, playerCount, playerId, seed: providedSeed } = params;
+    const { strategy: strategyName, playerCount, playerId, seed: providedSeed, strategyOptions } = params;
 
     // Validate strategy
     if (!strategies.has(strategyName)) {
@@ -152,7 +154,7 @@ export class SessionManager {
     const seed = providedSeed ?? randomUUID();
 
     // Instantiate strategy
-    const strat = strategies.get(strategyName)!();
+    const strat = strategies.get(strategyName)!(strategyOptions);
     const rng = createPlayerRng(seed, playerId);
     strat.onGameStart?.({ playerId, playerCount, rng });
 
@@ -160,6 +162,7 @@ export class SessionManager {
       id: sessionId,
       strategy: strat,
       strategyName,
+      strategyOptions,
       playerId,
       playerCount,
       seed,
@@ -605,7 +608,7 @@ export class SessionManager {
     if (!session) return errors.unknownSession(sessionId);
 
     // Re-instantiate strategy with fresh RNG
-    const strat = strategies.get(session.strategyName)!();
+    const strat = strategies.get(session.strategyName)!(session.strategyOptions);
     const rng = createPlayerRng(session.seed, session.playerId);
     strat.onGameStart?.({ playerId: session.playerId, playerCount: session.playerCount, rng });
 

--- a/src/mcp/tools/stateless.ts
+++ b/src/mcp/tools/stateless.ts
@@ -146,6 +146,7 @@ export function validateState(params: ValidateStateParams): ValidateStateResult 
 export interface RecommendOnceParams {
   state: Record<string, unknown>;
   strategy: string;
+  strategyOptions?: Record<string, unknown>;
   decision?: 'card' | 'row';
   timeout?: number;
 }
@@ -186,7 +187,7 @@ export function recommendOnce(params: RecommendOnceParams): RecommendOnceResult 
   }
 
   // Instantiate strategy
-  const strat = strategies.get(strategyName)!();
+  const strat = strategies.get(strategyName)!(params.strategyOptions);
   const playerCount = (state.playerCount as number) ?? 2;
   const seedStr = 'recommend/' + ((state as Record<string, unknown>).playerId ?? 'recommend-player');
   const rngState = deriveSeedState(seedStr);

--- a/src/sim/runner.ts
+++ b/src/sim/runner.ts
@@ -121,7 +121,7 @@ export function runGame(config: SimConfig): GameResult {
   const strategyMap = new Map<string, Strategy>();
   for (const p of players) {
     const factory = strategies.get(p.strategy)!;
-    strategyMap.set(p.id, factory(p.params));
+    strategyMap.set(p.id, factory(p.strategyOptions));
   }
 
   // 5. onGameStart

--- a/src/sim/runner.ts
+++ b/src/sim/runner.ts
@@ -121,7 +121,7 @@ export function runGame(config: SimConfig): GameResult {
   const strategyMap = new Map<string, Strategy>();
   for (const p of players) {
     const factory = strategies.get(p.strategy)!;
-    strategyMap.set(p.id, factory());
+    strategyMap.set(p.id, factory(p.params));
   }
 
   // 5. onGameStart

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -2,7 +2,7 @@ export interface SimConfig {
   readonly players: readonly {
     id: string;
     strategy: string;
-    params?: Record<string, unknown>;
+    strategyOptions?: Record<string, unknown>;
   }[];
   readonly seed?: string;
 }

--- a/test/engine/parseStrategySpec.test.ts
+++ b/test/engine/parseStrategySpec.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { parseStrategySpec } from '../../src/engine/strategies/index.js';
+import { parseStrategies } from '../../src/cli/helpers.js';
+
+describe('parseStrategySpec', () => {
+  it('parses bare strategy name', () => {
+    expect(parseStrategySpec('mcs')).toEqual({ name: 'mcs' });
+  });
+
+  it('parses strategy with numeric options', () => {
+    expect(parseStrategySpec('mcs:mcMax=500,mcPerCard=50')).toEqual({
+      name: 'mcs',
+      options: { mcMax: 500, mcPerCard: 50 },
+    });
+  });
+
+  it('parses strategy with string option', () => {
+    expect(parseStrategySpec('mcs:policy=greedy')).toEqual({
+      name: 'mcs',
+      options: { policy: 'greedy' },
+    });
+  });
+
+  it('parses flag-style params (no value)', () => {
+    expect(parseStrategySpec('mcs:debug')).toEqual({
+      name: 'mcs',
+      options: { debug: true },
+    });
+  });
+
+  it('handles trailing colon with no params', () => {
+    expect(parseStrategySpec('mcs:')).toEqual({ name: 'mcs' });
+  });
+
+  it('trims whitespace around keys and values', () => {
+    expect(parseStrategySpec('mcs: mcMax = 500 , mcPerCard = 50 ')).toEqual({
+      name: 'mcs',
+      options: { mcMax: 500, mcPerCard: 50 },
+    });
+  });
+
+  it('skips empty segments from trailing commas', () => {
+    expect(parseStrategySpec('mcs:mcMax=500,')).toEqual({
+      name: 'mcs',
+      options: { mcMax: 500 },
+    });
+  });
+});
+
+describe('parseStrategies', () => {
+  it('splits simple comma-separated strategies', () => {
+    expect(parseStrategies('mcs,random,bayesian-simple')).toEqual([
+      'mcs', 'random', 'bayesian-simple',
+    ]);
+  });
+
+  it('keeps key=val params with preceding colon-spec', () => {
+    expect(parseStrategies('mcs:mcMax=500,mcPerCard=50,random')).toEqual([
+      'mcs:mcMax=500,mcPerCard=50', 'random',
+    ]);
+  });
+
+  it('keeps flag params with =true syntax with preceding colon-spec', () => {
+    expect(parseStrategies('mcs:debug=true,mcMax=500,random')).toEqual([
+      'mcs:debug=true,mcMax=500', 'random',
+    ]);
+  });
+
+  it('handles JSON array format', () => {
+    expect(parseStrategies('["mcs","random"]')).toEqual(['mcs', 'random']);
+  });
+
+  it('handles multiple parameterized strategies', () => {
+    expect(parseStrategies('mcs:mcMax=500,bayesian-simple,random')).toEqual([
+      'mcs:mcMax=500', 'bayesian-simple', 'random',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Monte-Carlo Search (MCS) strategy based on Brehmer & Gutsche's [rl-6-nimmt](https://github.com/johannbrehmer/rl-6nimmt) research, plus infrastructure for passing strategy-specific parameters across CLI, MCP, and simulator.

## What's included

### MCS Strategy (\src/engine/strategies/mcs.ts\)
- Full-round Monte-Carlo search: simulates entire remaining round with sampled opponent hands
- Configurable via \McsOptions\: \mcPerCard\ (default 50) and \mcMax\ (default 500)
- At recommended settings, achieves **82% win rate vs random** and **75% win rate vs bayesian-simple**

### Strategy Options Plumbing
- Registry factory type now accepts \(opts?: Record<string, unknown>) => Strategy\
- **CLI:** colon syntax \-s mcs:mcPerCard=50,mcMax=500\
- **MCP:** \strategyOptions\ field in \start_session\ and \ecommend_once\
- **Simulator:** \strategyOptions\ field in \SimConfig\ player entries

### Spec & Results
- \spec/strategies/mcts.md\ — algorithm design, config, benchmark tables
- \project/results/mcs.md\ — full benchmark report with analysis

## Benchmark highlights (4 players, 100 games)

| Config | vs Random (win%) | vs Bayesian (win%) | Time/game |
|--------|-----------------|-------------------|-----------| 
| mcs (10/card) | 64% | 40% | 57ms |
| mcs (20/card) | 74% | 61% | 108ms |
| **mcs (50/card)** | **82%** | **75%** | **270ms** |
| bayesian-simple | 70% | — | 567ms |

MCS@50 is both stronger AND faster than bayesian-simple.

## All 401 tests pass