### PR TITLE
docs: README and docs/ folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,94 @@
 # 6-nimmt-agent
-An advisor to play the 6 Nimmt card game online
+
+> A TypeScript engine and autonomous player for the card game [6 Nimmt!](https://en.wikipedia.org/wiki/6_nimmt!) — built to play live on [Board Game Arena](https://boardgamearena.com/gamepanel?game=sechsnimmt) and benchmark AI strategies against real humans.
+
+---
+
+## What is this?
+
+6 Nimmt! is a deceptively simple card game: 104 cards, 4 rows on the table, everyone plays simultaneously. Your card goes to the nearest row tail lower than it — but if you land in the 6th slot, you take the whole row as penalty points. The lowest score wins.
+
+The rules are fully deterministic. The interesting problem is **predicting where opponents will play** and avoiding the chaos.
+
+This repo is a research project exploring that problem:
+
+- 🎮 **Play autonomously** on BGA using Monte Carlo simulation in ~2ms per decision
+- 📊 **Benchmark strategies** — random baseline, heuristic, Bayesian, MCS — against each other
+- 📁 **Collect game data** in streaming JSONL for post-game analysis
+- 🔬 **Iterate fast** — simulate 1000 games in seconds without touching a browser
+
+---
+
+## Quick start
+
+```bash
+npm install
+
+# Simulate 1000 games: MCS vs 4 random players
+npx tsx src/cli/index.ts simulate --strategies mcs,random,random,random,random --games 1000
+
+# Play live on BGA (Chrome/Edge required)
+export BGA_USERNAME=you
+export BGA_PASSWORD=secret
+npm run play -- --strategy mcs --verbose
+```
+
+---
+
+## Architecture
+
+```
+src/
+├── engine/       Pure TypeScript game engine — rules, state, strategies
+├── cli/          Simulate and benchmark strategies offline
+├── sim/          Game runner for batch simulations
+├── player/       Headless Playwright player for live BGA games
+└── mcp/          MCP server for Copilot agent integration
+```
+
+The game loop is 100% deterministic — no LLM in the play path. The engine calls a strategy directly in-process. The Playwright player polls BGA's DOM every 500ms, reads card values from CSS sprites, and clicks via `el.click()` (Playwright's visibility checks don't work on BGA's animated elements).
+
+---
+
+## Strategies
+
+| Strategy | Description |
+|---|---|
+| `random` | Uniform random — the baseline |
+| `heuristic` | Rule-based: avoid rows near 5, prefer safe placements |
+| `bayesian` | Expected-penalty minimisation over unseen card distribution |
+| `mcs` | Monte Carlo Simulation — strongest; simulates random game completions |
+
+```bash
+# Tune MCS iterations
+npm run play -- --strategy mcs:mcMax=2000,mcPerCard=200
+```
+
+---
+
+## Documentation
+
+| Doc | Description |
+|---|---|
+| [Getting Started](docs/getting-started.md) | Install, CLI, first live game |
+| [Strategies](docs/strategies.md) | All strategies, options, benchmarking |
+| [Headless Player](docs/headless-player.md) | Live BGA player in depth |
+| [Simulator](docs/simulator.md) | Batch simulation and benchmarking |
+| [Data Capture](docs/data-capture.md) | JSONL game log format |
+| [Game Rules](spec/rules/6-nimmt.md) | 6 Nimmt! rules reference |
+
+---
+
+## Development
+
+```bash
+npm test          # 413 tests
+npm run lint      # ESLint
+npm run build     # tsc
+```
+
+---
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The rules are fully deterministic. The interesting problem is **predicting where
 This repo is a research project exploring that problem:
 
 - 🎮 **Play autonomously** on BGA using Monte Carlo simulation in ~2ms per decision
-- 📊 **Benchmark strategies** — random baseline, heuristic, Bayesian, MCS — against each other
+- 📊 **Benchmark strategies** — random baseline, Bayesian, MCS — against each other
 - 📁 **Collect game data** in streaming JSONL for post-game analysis
 - 🔬 **Iterate fast** — simulate 1000 games in seconds without touching a browser
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ The game loop is 100% deterministic — no LLM in the play path. The engine call
 | Strategy | Description |
 |---|---|
 | `random` | Uniform random — the baseline |
-| `heuristic` | Rule-based: avoid rows near 5, prefer safe placements |
-| `bayesian` | Expected-penalty minimisation over unseen card distribution |
+| `dummy-min` | Always plays the lowest card in hand |
+| `dummy-max` | Always plays the highest card in hand |
+| `bayesian-simple` | Expected-penalty minimisation over unseen card distribution |
 | `mcs` | Monte Carlo Simulation — strongest; simulates random game completions |
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ npm install
 # Simulate 1000 games: MCS vs 4 random players
 npx tsx src/cli/index.ts simulate --strategies mcs,random,random,random,random --games 1000
 
-# Play live on BGA (Chrome/Edge required)
-export BGA_USERNAME=you
-export BGA_PASSWORD=secret
+# Play live on BGA — log in and join a table in Chrome/Edge first, then:
 npm run play -- --strategy mcs --verbose
 ```
 

--- a/data/index.json
+++ b/data/index.json
@@ -1,0 +1,28 @@
+{
+  "games": [
+    {
+      "file": "games/2026-04-30_bga_68d9ccff.jsonl",
+      "gameId": "68d9ccff",
+      "date": "2026-04-30",
+      "playerCount": 2,
+      "strategy": "mcs",
+      "finalScores": {
+        "88075076": 66,
+        "91891658": 66
+      }
+    },
+    {
+      "file": "games/2026-04-30_bga_c91bb5b5.jsonl",
+      "gameId": "c91bb5b5",
+      "date": "2026-04-30",
+      "playerCount": 4,
+      "strategy": "mcs",
+      "finalScores": {
+        "84557533": 66,
+        "88075076": 66,
+        "90975950": 66,
+        "99205691": 66
+      }
+    }
+  ]
+}

--- a/docs/data-capture.md
+++ b/docs/data-capture.md
@@ -1,0 +1,79 @@
+# Data Capture
+
+During live play, the headless player streams game events to a JSONL file in `data/games/`. Every event is written immediately — no data is lost if the script crashes mid-game.
+
+## File format
+
+One JSON object per line. File name: `data/games/YYYY-MM-DD_bga_XXXXXXXX.jsonl`
+
+## Event types
+
+### `gameStart`
+```json
+{"event":"gameStart","gameId":"bga_a1b2c3d4","playerCount":5,"strategy":"mcs","timestamp":"..."}
+```
+
+### `roundStart`
+```json
+{"event":"roundStart","round":1,"initialBoard":[[5],[22],[47],[81]],"dealtHand":[3,18,35,62,70,77,88,91,98,103],"timestamp":"..."}
+```
+
+### `turn`
+```json
+{"event":"turn","round":1,"turn":3,"ourCard":35,"recommendation":35,"boardBefore":[[5,12],[22],[47,51],[81,88]],"decision":{"hand":[3,35,62,70,77,88,91,98,103],"strategyUsed":"mcs","timeToDecide":8},"timestamp":"..."}
+```
+
+### `boardAfter`
+```json
+{"event":"boardAfter","round":1,"boardAfter":[[5,12,35],[22],[47,51],[81,88]],"timestamp":"..."}
+```
+
+### `rowPick`
+```json
+{"event":"rowPick","round":1,"row":2,"boardBefore":[[5,12,35],[22],[47,51,55,60,65],[81,88]],"timestamp":"..."}
+```
+
+### `roundEnd`
+```json
+{"event":"roundEnd","round":1,"scores":{"seat0":3,"seat1":7,"seat2":0,"seat3":12,"seat4":5},"timestamp":"..."}
+```
+
+### `gameEnd`
+```json
+{"event":"gameEnd","finalScores":{"seat0":18,"seat1":34,"seat2":11,"seat3":42,"seat4":27},"rounds":8,"timestamp":"..."}
+```
+
+### `error`
+```json
+{"event":"error","message":"Failed to play card 62: Card 62 not found","timestamp":"..."}
+```
+
+## Privacy
+
+- No player names or BGA user IDs are stored — only seat indices (seat0–seatN)
+- No chat or spectator data
+- No credentials or session tokens
+
+## Index
+
+A lightweight index is maintained at `data/index.json`:
+```json
+[
+  {"gameId":"bga_a1b2c3d4","file":"data/games/2026-04-29_bga_a1b2c3d4.jsonl","playerCount":5,"strategy":"mcs","rounds":8,"timestamp":"..."}
+]
+```
+
+## Analysis ideas
+
+The JSONL format is easy to analyse:
+
+```bash
+# Count games played
+wc -l data/index.json
+
+# Extract all cards we played
+grep '"event":"turn"' data/games/*.jsonl | jq '.ourCard'
+
+# Find turns where we picked a row
+grep '"event":"rowPick"' data/games/*.jsonl
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,21 +34,14 @@ npx tsx src/cli/index.ts simulate --strategies bayesian,random --games 500 --for
 
 The headless player attaches to your browser and plays autonomously.
 
-### 1. Set credentials
+### 1. Join a table on BGA
+
+Open BGA in Chrome or Edge, log in, and join (or create) a 6 Nimmt! table. Get to the game page.
+
+### 2. Run the player
 
 ```bash
-export BGA_USERNAME=your_username
-export BGA_PASSWORD=your_password
-```
-
-### 2. Join a table on BGA
-
-Open BGA in Chrome or Edge, log in, and join (or create) a 6 Nimmt! table.
-
-### 3. Run the player
-
-```bash
-# Connect to your running browser (Chrome/Edge must already be open)
+# Connect to your running browser (Chrome/Edge must already be open at the game page)
 npm run play -- --strategy mcs
 
 # With strategy tuning
@@ -58,7 +51,7 @@ npm run play -- --strategy mcs:mcMax=1000,mcPerCard=100 --verbose
 npm run play -- --strategy mcs --delay 2000
 ```
 
-The script connects to your browser via Chrome DevTools Protocol (CDP). If no browser is found running on port 9222, it launches one automatically and prompts you to log in and join a table.
+The script connects to your browser via Chrome DevTools Protocol (CDP) on port 9222.
 
 ## Run tests
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,74 @@
+# Getting Started
+
+## Prerequisites
+
+- Node.js 20+
+- npm
+- A [Board Game Arena](https://boardgamearena.com) account (for live play)
+- Chrome or Microsoft Edge (for the headless player)
+
+## Install
+
+```bash
+git clone https://github.com/ThingsAI-io/6-nimmt-agent
+cd 6-nimmt-agent
+npm install
+```
+
+## Run the CLI
+
+The CLI simulates games between strategies — no browser needed.
+
+```bash
+# Run 1000 games: MCS vs 4 random players
+npx tsx src/cli/index.ts simulate --strategies mcs,random,random,random,random --games 1000
+
+# List all available strategies
+npx tsx src/cli/index.ts strategies
+
+# Output as JSON
+npx tsx src/cli/index.ts simulate --strategies bayesian,random --games 500 --format json
+```
+
+## Play live on Board Game Arena
+
+The headless player attaches to your browser and plays autonomously.
+
+### 1. Set credentials
+
+```bash
+export BGA_USERNAME=your_username
+export BGA_PASSWORD=your_password
+```
+
+### 2. Join a table on BGA
+
+Open BGA in Chrome or Edge, log in, and join (or create) a 6 Nimmt! table.
+
+### 3. Run the player
+
+```bash
+# Connect to your running browser (Chrome/Edge must already be open)
+npm run play -- --strategy mcs
+
+# With strategy tuning
+npm run play -- --strategy mcs:mcMax=1000,mcPerCard=100 --verbose
+
+# Add a delay before each play (looks more human)
+npm run play -- --strategy mcs --delay 2000
+```
+
+The script connects to your browser via Chrome DevTools Protocol (CDP). If no browser is found running on port 9222, it launches one automatically and prompts you to log in and join a table.
+
+## Run tests
+
+```bash
+npm test
+```
+
+## Next steps
+
+- [Strategies](strategies.md) — available strategies and how to tune them
+- [Headless Player](headless-player.md) — full live player documentation
+- [Simulator](simulator.md) — benchmark strategies against each other
+- [Data Capture](data-capture.md) — game data collected during live play

--- a/docs/headless-player.md
+++ b/docs/headless-player.md
@@ -1,0 +1,85 @@
+# Headless Player
+
+A standalone TypeScript Playwright script that autonomously plays 6 Nimmt! on Board Game Arena using the strategy engine directly — no LLM in the loop.
+
+**Performance:** ~2ms per decision, ~2s per full turn (dominated by BGA animations).
+
+## How it works
+
+```
+Browser (Chrome/Edge)
+  └─ CDP (port 9222)
+       └─ play.ts
+            ├─ state-reader.ts  → reads hand/board from live DOM
+            ├─ loop.ts          → poll → decide → act
+            ├─ actor.ts         → clicks card / row arrow
+            ├─ collector.ts     → streams events to JSONL
+            └─ strategy engine  → in-process, no MCP
+```
+
+The player polls BGA's page title and gamestate every 500ms to detect when it's our turn. It reads card values by decoding CSS sprite background-positions (the BGA DOM doesn't expose card values directly).
+
+## Setup
+
+### 1. Credentials
+
+```bash
+export BGA_USERNAME=your_username
+export BGA_PASSWORD=your_password
+```
+
+### 2. Join a game
+
+Open Chrome or Edge, navigate to BGA, log in, and join a 6 Nimmt! table. Get to the game page.
+
+### 3. Start the player
+
+```bash
+npm run play -- --strategy mcs
+```
+
+The script finds your browser via CDP on port 9222. If no browser is running there, it launches one automatically.
+
+## Command reference
+
+```
+npm run play -- [options]
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `--strategy` | (required) | Strategy name, optionally with options: `mcs:mcMax=1000` |
+| `--browser` | `msedge` | Browser to launch if needed: `chrome`, `msedge`, `chromium` |
+| `--port` | `9222` | CDP remote debugging port |
+| `--delay` | `0` | Milliseconds to wait before each play (simulates human timing) |
+| `--verbose` / `-v` | `false` | Log every action to stdout |
+| `--no-collect` | `false` | Disable JSONL data collection |
+| `--player-count` | (auto) | Override detected player count |
+| `--timeout` | `180000` | Max ms to wait for our turn before giving up |
+
+## Data collection
+
+Every game is saved to `data/games/YYYY-MM-DD_bga_XXXXXXXX.jsonl`. Each line is a JSON event:
+
+| Event | Description |
+|---|---|
+| `gameStart` | Player count, strategy, game ID |
+| `roundStart` | Initial board and dealt hand |
+| `turn` | Card played, board before, strategy decision |
+| `boardAfter` | Board state after all cards resolved |
+| `rowPick` | Which row we picked up and why |
+| `roundEnd` | Scores after round |
+| `gameEnd` | Final scores |
+
+Events are written immediately — no data is lost if the script crashes.
+
+## DOM quirks
+
+BGA's DOM has several gotchas that the player works around:
+
+- **Stale `gamedatas`**: `gameui.gamedatas.hand` is frozen at page load. We read the live `playerHand` Stock component instead.
+- **Sprite decoding**: Card values aren't in the DOM — they're encoded as CSS `background-position` on sprite elements. Formula: `value = (|Y%|/100)*10 + (|X%|/100) + 1`
+- **JS clicks**: Playwright's built-in click() fails on BGA elements due to animation states. We use `el.click()` via `page.evaluate()` instead.
+- **Row pick detection**: The "must take a row" title appears for both our turn and opponents'. We check arrow visibility to confirm it's actually our turn.
+
+See `src/player/state-reader.ts` and `src/player/actor.ts` for full details.

--- a/docs/headless-player.md
+++ b/docs/headless-player.md
@@ -21,24 +21,17 @@ The player polls BGA's page title and gamestate every 500ms to detect when it's 
 
 ## Setup
 
-### 1. Credentials
+### 1. Join a table on BGA
 
-```bash
-export BGA_USERNAME=your_username
-export BGA_PASSWORD=your_password
-```
+Open Chrome or Edge, log in to [Board Game Arena](https://boardgamearena.com), and join a 6 Nimmt! table. Get to the game page.
 
-### 2. Join a game
-
-Open Chrome or Edge, navigate to BGA, log in, and join a 6 Nimmt! table. Get to the game page.
-
-### 3. Start the player
+### 2. Start the player
 
 ```bash
 npm run play -- --strategy mcs
 ```
 
-The script finds your browser via CDP on port 9222. If no browser is running there, it launches one automatically.
+The script connects to your browser via CDP on port 9222.
 
 ## Command reference
 

--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -1,0 +1,64 @@
+# Simulator
+
+The simulator runs complete games between configurable strategy combinations entirely in memory — no browser, no BGA, no network. Use it to benchmark strategies and measure improvement.
+
+## Basic usage
+
+```bash
+# MCS vs 4 random players
+npx tsx src/cli/index.ts simulate \
+  --strategies mcs,random,random,random,random \
+  --games 1000
+
+# Two strategies head to head
+npx tsx src/cli/index.ts simulate \
+  --strategies bayesian,mcs \
+  --games 500
+
+# Reproducible run with a seed
+npx tsx src/cli/index.ts simulate \
+  --strategies mcs,random,random \
+  --games 1000 \
+  --seed my-seed-42
+```
+
+## Output
+
+Default table output:
+
+```
+Strategy   Games   Win%    Avg Score   Std Dev
+mcs        1000    58.2%   32.1        8.4
+random     1000    41.8%   47.6        12.1
+```
+
+JSON output (for scripting):
+
+```bash
+npx tsx src/cli/index.ts simulate \
+  --strategies mcs,random \
+  --games 1000 \
+  --format json
+```
+
+## Strategy options in simulations
+
+Pass options using colon syntax:
+
+```bash
+npx tsx src/cli/index.ts simulate \
+  --strategies "mcs:mcMax=200,random,random,random" \
+  --games 500
+```
+
+## Player count
+
+The number of players is inferred from the number of strategies. Pass 2–10 strategies.
+
+## Reproducibility
+
+The `--seed` flag fixes the RNG so results are reproducible across runs:
+
+```bash
+npx tsx src/cli/index.ts simulate --strategies mcs,random --games 100 --seed abc123
+```

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -8,30 +8,32 @@ The engine ships with several pluggable strategies. All implement the same inter
 
 Picks a card uniformly at random. Used as the baseline in benchmarks.
 
-No options.
-
 ```bash
 npm run play -- --strategy random
 ```
 
-### `heuristic` (greedy)
+### `dummy-min`
 
-Simple rule-based play. Prefers cards that place safely on a row (far from the 6th slot) and avoids rows with high cattle-head penalties.
-
-No options.
+Always plays the lowest card in hand.
 
 ```bash
-npm run play -- --strategy heuristic
+npm run play -- --strategy dummy-min
 ```
 
-### `bayesian`
+### `dummy-max`
+
+Always plays the highest card in hand.
+
+```bash
+npm run play -- --strategy dummy-max
+```
+
+### `bayesian-simple`
 
 Maintains a probability distribution over cards not yet seen. Evaluates expected penalty for each candidate card given the current board and known card distribution.
 
-No options.
-
 ```bash
-npm run play -- --strategy bayesian
+npm run play -- --strategy bayesian-simple
 ```
 
 ### `mcs` — Monte Carlo Simulation
@@ -66,7 +68,7 @@ npx tsx src/cli/index.ts simulate \
 
 # Bayesian vs MCS (2-player, 500 games)
 npx tsx src/cli/index.ts simulate \
-  --strategies bayesian,mcs \
+  --strategies bayesian-simple,mcs \
   --games 500
 ```
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,0 +1,83 @@
+# Strategies
+
+The engine ships with several pluggable strategies. All implement the same interface — `chooseCard()` and `chooseRow()` — so they can be swapped freely in simulations or live play.
+
+## Available strategies
+
+### `random`
+
+Picks a card uniformly at random. Used as the baseline in benchmarks.
+
+No options.
+
+```bash
+npm run play -- --strategy random
+```
+
+### `heuristic` (greedy)
+
+Simple rule-based play. Prefers cards that place safely on a row (far from the 6th slot) and avoids rows with high cattle-head penalties.
+
+No options.
+
+```bash
+npm run play -- --strategy heuristic
+```
+
+### `bayesian`
+
+Maintains a probability distribution over cards not yet seen. Evaluates expected penalty for each candidate card given the current board and known card distribution.
+
+No options.
+
+```bash
+npm run play -- --strategy bayesian
+```
+
+### `mcs` — Monte Carlo Simulation
+
+The strongest strategy. Simulates many random completions of the game from the current state and picks the card with the best expected score.
+
+**Options:**
+
+| Option | Default | Description |
+|---|---|---|
+| `mcMax` | `500` | Total number of Monte Carlo iterations |
+| `mcPerCard` | `50` | Iterations per candidate card |
+
+```bash
+# Default
+npm run play -- --strategy mcs
+
+# More iterations (slower but stronger)
+npm run play -- --strategy mcs:mcMax=2000,mcPerCard=200
+```
+
+## Benchmarking strategies
+
+Use the simulator to compare strategies over many games:
+
+```bash
+# MCS vs 4 random players (1000 games)
+npx tsx src/cli/index.ts simulate \
+  --strategies mcs,random,random,random,random \
+  --games 1000 \
+  --format json
+
+# Bayesian vs MCS (2-player, 500 games)
+npx tsx src/cli/index.ts simulate \
+  --strategies bayesian,mcs \
+  --games 500
+```
+
+## Strategy options syntax
+
+Options are passed as colon-separated `key=val` pairs after the strategy name:
+
+```
+--strategy mcs:mcMax=1000,mcPerCard=100
+```
+
+## Row pick
+
+All strategies also implement `chooseRow()` for when your card is lower than all row tails and you must pick up a row. Most strategies default to picking the row with the fewest cattle heads.


### PR DESCRIPTION
Adds a proper README and a docs/ folder.

**README.md** — memorable project overview with quick start, architecture, strategy table, and links to all docs.

**docs/**
- getting-started.md — install, CLI usage, live play setup
- strategies.md — all strategies, options, benchmarking recipes
- headless-player.md — live player deep-dive including DOM quirks
- simulator.md — batch simulation and benchmarking
- data-capture.md — JSONL event format and analysis tips