### PR TITLE
feat: rich error diagnostics in headless player

### DIFF
--- a/src/player/actor.ts
+++ b/src/player/actor.ts
@@ -13,7 +13,6 @@
  *   Element IDs (myhand_item_X) use internal stock IDs that change between renders.
  */
 import type { Page } from 'playwright';
-import type { HandItem } from './state-reader.js';
 import type { CardNumber } from '../engine/types.js';
 
 /**
@@ -25,7 +24,7 @@ import type { CardNumber } from '../engine/types.js';
  * hand items, decode each card's value from its sprite, and click the one
  * that matches our target value.
  */
-export async function playCard(page: Page, _hand: HandItem[], cardValue: CardNumber): Promise<void> {
+export async function playCard(page: Page, cardValue: CardNumber): Promise<void> {
   const result = await page.evaluate((targetValue: number) => {
     const gu = (window as any).gameui;
     if (!gu?.playerHand) return { ok: false, error: 'no playerHand' };
@@ -73,15 +72,19 @@ export async function playCard(page: Page, _hand: HandItem[], cardValue: CardNum
  * These arrows have class "selectable_row" when clickable, but their CSS
  * display/visibility can still confuse Playwright — so we use JS click first,
  * falling back to Playwright's force-click if the element isn't found via JS.
+ *
+ * SAFETY: We verify selectable_row class before clicking to prevent acting
+ * on a row that's visible but belongs to an opponent's turn.
  */
 export async function pickRow(page: Page, rowIndex: 0 | 1 | 2 | 3): Promise<void> {
   const domIndex = rowIndex + 1; // Convert 0-indexed to BGA's 1-indexed DOM
   const selector = `#row_slot_${domIndex}_arrow`;
 
-  // Primary: JS click via evaluate (most reliable for BGA elements)
+  // Primary: JS click via evaluate — verify selectable_row class first
   const clicked = await page.evaluate((sel: string) => {
     const el = document.querySelector(sel) as HTMLElement | null;
     if (!el) return false;
+    if (!el.classList.contains('selectable_row')) return false;
     el.click();
     return true;
   }, selector);

--- a/src/player/logger.ts
+++ b/src/player/logger.ts
@@ -9,9 +9,19 @@ export interface LogEntry {
 
 /**
  * Log an action as structured JSON to stdout.
+ * Gated by verbose — not emitted in silent mode.
  */
 export function log(entry: LogEntry, verbose: boolean = true): void {
   if (!verbose) return;
   const timestamp = new Date().toISOString();
   console.log(JSON.stringify({ ...entry, timestamp }));
+}
+
+/**
+ * Log an error event to stderr always — regardless of verbose flag.
+ * Errors are never silenced because they are critical for debugging.
+ */
+export function logError(entry: LogEntry): void {
+  const timestamp = new Date().toISOString();
+  console.error(JSON.stringify({ ...entry, timestamp }));
 }

--- a/src/player/logger.ts
+++ b/src/player/logger.ts
@@ -10,18 +10,24 @@ export interface LogEntry {
 /**
  * Log an action as structured JSON to stdout.
  * Gated by verbose — not emitted in silent mode.
+ * Respects existing timestamp if present; adds one otherwise.
  */
 export function log(entry: LogEntry, verbose: boolean = true): void {
   if (!verbose) return;
-  const timestamp = new Date().toISOString();
-  console.log(JSON.stringify({ ...entry, timestamp }));
+  if (!entry.timestamp) {
+    entry = { ...entry, timestamp: new Date().toISOString() };
+  }
+  console.log(JSON.stringify(entry));
 }
 
 /**
  * Log an error event to stderr always — regardless of verbose flag.
  * Errors are never silenced because they are critical for debugging.
+ * Respects existing timestamp if present; adds one otherwise.
  */
 export function logError(entry: LogEntry): void {
-  const timestamp = new Date().toISOString();
-  console.error(JSON.stringify({ ...entry, timestamp }));
+  if (!entry.timestamp) {
+    entry = { ...entry, timestamp: new Date().toISOString() };
+  }
+  console.error(JSON.stringify(entry));
 }

--- a/src/player/loop.ts
+++ b/src/player/loop.ts
@@ -360,6 +360,26 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
         round: currentRound,
         turn: turnsPlayed,
       });
+
+      // Wait for BGA to leave the row-pick state before looping.
+      // Without this, detectAction() sees the title still saying "must take a row"
+      // and selectable_row arrows on the next poll, causing repeated row picks.
+      // Poll until selectable_row arrows disappear (BGA confirmed our pick).
+      await page.waitForTimeout(500);
+      for (let i = 0; i < 20; i++) {
+        const pickDone = await page.evaluate(() => {
+          const arrows = (window as any).document.querySelectorAll(
+            '#row_slot_1_arrow, #row_slot_2_arrow, #row_slot_3_arrow, #row_slot_4_arrow'
+          );
+          let anySelectable = false;
+          arrows.forEach((el: any) => {
+            if (el.classList.contains('selectable_row')) anySelectable = true;
+          });
+          return !anySelectable;
+        });
+        if (pickDone) break;
+        await page.waitForTimeout(300);
+      }
     }
 
     // Wait for BGA animations to resolve (card placement, row clearing, etc.)

--- a/src/player/loop.ts
+++ b/src/player/loop.ts
@@ -13,6 +13,15 @@
  *   and try to play the same card again.
  * - When hand empties (all 10 cards played), we enter a wait loop for either
  *   new round deal (hand > 0) or game end (gamestate name check).
+ *
+ * KNOWN LIMITATIONS:
+ * - Strategy lifecycle: we call onGameStart() but NOT onTurnResolved() or
+ *   onRoundEnd(). Live play cannot reliably reconstruct opponent cards from DOM,
+ *   so turnHistory and revealedThisTurn are passed as empty arrays. Strategies
+ *   that rely on seen-card tracking (bayesian, mcs) operate in degraded mode.
+ *   TODO: Parse resolved cards from BGA animations/log to feed onTurnResolved.
+ * - Round numbers are "rounds since attachment" — reconnecting mid-game starts
+ *   at round 1 even if the true game round is higher.
  */
 import type { Page } from 'playwright';
 import type { Strategy } from '../engine/strategies/types.js';
@@ -70,7 +79,7 @@ async function waitForAction(
  * The main loop resumes and calls `waitForAction` which will correctly wait
  * for the next interactive state.
  */
-async function waitForTurnResolution(page: Page, timeout: number): Promise<void> {
+async function waitForTurnResolution(page: Page, timeout: number, emit: (entry: Record<string, unknown>) => void): Promise<void> {
   const startTime = Date.now();
   while (Date.now() - startTime < timeout) {
     const leftCardSelect = await page.evaluate(() => {
@@ -81,7 +90,9 @@ async function waitForTurnResolution(page: Page, timeout: number): Promise<void>
     if (leftCardSelect) return;
     await page.waitForTimeout(300);
   }
-  // Timeout is non-fatal — main waitForAction will handle it
+  // Timeout is suspicious — log it so we can detect stuck states in diagnostics.
+  // Non-fatal: the main waitForAction loop will handle the next iteration.
+  emit({ event: 'warning', message: `waitForTurnResolution timed out after ${timeout}ms` });
 }
 
 /**
@@ -229,7 +240,7 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
       // Attempt card play — on failure, emit enriched error with full context
       const stateReadAt = Date.now();
       try {
-        await playCard(page, state.hand, card);
+        await playCard(page, card);
       } catch (err) {
         const dom = await captureErrorContext(page);
         logError({
@@ -273,6 +284,17 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
       lastPlayedCard = card; // track for potential row pick that follows
       turnsPlayed++;
 
+      // Emit immediately after successful click — NOT after resolution waits.
+      // This gives accurate timestamps reflecting when the decision was executed.
+      emit({
+        event: 'playCard',
+        card,
+        round: currentRound,
+        turn: currentTurn,
+        handSize: state.hand.length - 1,
+        decisionTime,
+      });
+
       // CRITICAL: Wait for card to actually leave hand before continuing.
       // Without this, the next loop iteration would read the same hand state
       // (card still animating out) and try to play the same card again.
@@ -290,9 +312,9 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
       // This prevents waitForAction from firing 'playCard' again while other players
       // are still selecting (gamestate stays 'cardSelect' until all have submitted).
       // Fixes: agent re-running strategy and clicking a second card mid-turn.
-      await waitForTurnResolution(page, 30_000);
+      await waitForTurnResolution(page, 30_000, emit);
 
-      // Record turn data
+      // Record turn data for training/analysis collection
       collector?.recordTurn({
         turn: currentTurn,
         ourCard: card as number,
@@ -306,22 +328,13 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
         },
       });
 
-      emit({
-        event: 'playCard',
-        card,
-        round: currentRound,
-        turn: currentTurn,
-        handSize: state.hand.length - 1,
-        decisionTime,
-      });
-
     } else if (action === 'pickRow') {
       // Row pick: our played card was lower than all row tails, so we must
       // pick a row to take (absorb its penalty points). Strategy decides which;
       // fallback to cheapest row (fewest cattle heads) if strategy throws.
       let rowIdx: 0 | 1 | 2 | 3;
       try {
-        const rowState = buildRowChoiceState(state, playerCount, currentRound, turnsPlayed, lastPlayedCard);
+        const rowState = buildRowChoiceState(state, playerCount, currentRound, currentTurn, lastPlayedCard);
         rowIdx = strategy.chooseRow(rowState);
       } catch {
         rowIdx = findCheapestRow(state.board);
@@ -348,6 +361,25 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
           },
           lastEvents: [...eventBuffer],
         });
+
+        // Same abrupt-end handling as playCard — game may have ended mid-action
+        const TERMINAL_STATES = ['gameEnd', 'endGame', 'gameOver'];
+        const abruptEnd = await page.evaluate((terminals: string[]) => {
+          const gs = (window as any).gameui?.gamedatas?.gamestate;
+          const gsName: string = gs?.name ?? '';
+          return terminals.includes(gsName);
+        }, TERMINAL_STATES).catch(() => true);
+
+        if (abruptEnd) {
+          emit({ event: 'gameAborted', reason: 'row pick failed in terminal state', gamestateName: dom.gamestateName });
+          const scores = await getFinalScores(page).catch(() => ({}));
+          if (collector) {
+            collector.endRound(scores);
+            collector.finalize(scores);
+          }
+          return { scores, turnsPlayed, rounds: currentRound };
+        }
+
         throw err;
       }
 
@@ -358,7 +390,7 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
         event: 'pickRow',
         row: rowIdx,
         round: currentRound,
-        turn: turnsPlayed,
+        turn: currentTurn,
       });
 
       // Wait for BGA to leave the row-pick state before looping.

--- a/src/player/loop.ts
+++ b/src/player/loop.ts
@@ -222,15 +222,15 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
         });
 
         // Before crashing: check if the game ended abruptly (e.g. a player quit).
-        // BGA may not cleanly emit gameEnd — it can silently transition to cardReveal
-        // or another terminal state. If the game is over, exit gracefully.
-        const abruptEnd = await page.evaluate(() => {
+        // Only treat as abrupt end if the gamestate is a known terminal state.
+        // Non-interactive states like cardProcess/cardReveal are normal mid-game
+        // states — we should NOT abort for those (they'll resolve and play continues).
+        const TERMINAL_STATES = ['gameEnd', 'endGame', 'gameOver'];
+        const abruptEnd = await page.evaluate((terminals: string[]) => {
           const gs = (window as any).gameui?.gamedatas?.gamestate;
           const gsName: string = gs?.name ?? '';
-          // If we can't find the card and the gamestate is non-interactive,
-          // the game likely ended without a clean gameEnd transition.
-          return gsName !== 'cardSelect' && gsName !== 'playerTurn';
-        }).catch(() => true); // if evaluate fails, assume game ended
+          return terminals.includes(gsName);
+        }, TERMINAL_STATES).catch(() => true); // if evaluate fails, assume game ended
 
         if (abruptEnd) {
           emit({ event: 'gameAborted', reason: 'card not found in non-interactive state', gamestateName: dom.gamestateName });

--- a/src/player/loop.ts
+++ b/src/player/loop.ts
@@ -17,9 +17,9 @@
 import type { Page } from 'playwright';
 import type { Strategy } from '../engine/strategies/types.js';
 import type { CardChoiceState, RowChoiceState, CardNumber } from '../engine/types.js';
-import { readGameState, detectAction, getFinalScores, findCheapestRow, type GameStateFromDOM } from './state-reader.js';
+import { readGameState, detectAction, getFinalScores, findCheapestRow, captureErrorContext, type GameStateFromDOM } from './state-reader.js';
 import { playCard, pickRow } from './actor.js';
-import { log } from './logger.js';
+import { log, logError } from './logger.js';
 import { GameCollector } from './collector.js';
 
 export interface PlayOptions {
@@ -68,6 +68,18 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
   let currentRound = 1;
   let lastHandSize = 0;
 
+  // Ring buffer: keep last 10 log entries in memory for error diagnostics.
+  // When an error occurs, we attach this to the error event so callers can
+  // see exactly what happened in the turns leading up to the crash.
+  const eventBuffer: Record<string, unknown>[] = [];
+  const RING_SIZE = 10;
+  function emit(entry: Record<string, unknown>): void {
+    const stamped = { ...entry, timestamp: new Date().toISOString() };
+    eventBuffer.push(stamped);
+    if (eventBuffer.length > RING_SIZE) eventBuffer.shift();
+    log(stamped as any, verbose);
+  }
+
   // Initialize strategy with game metadata
   const initialState = await readGameState(page);
   const playerCount = opts.playerCount ?? initialState.playerCount;
@@ -98,18 +110,30 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
 
   while (true) {
     // 1. Wait for our turn or game end
-    const action = await waitForAction(page, timeout);
+    let action: 'playCard' | 'pickRow' | 'gameEnd';
+    try {
+      action = await waitForAction(page, timeout);
+    } catch (err) {
+      const dom = await captureErrorContext(page);
+      logError({
+        event: 'error',
+        message: (err as Error).message,
+        context: { action: 'waitForAction', dom },
+        lastEvents: [...eventBuffer],
+      });
+      throw err;
+    }
 
     if (action === 'gameEnd') {
       const scores = await getFinalScores(page);
-      log({ event: 'gameEnd', scores, turnsPlayed, rounds: currentRound }, verbose);
+      emit({ event: 'gameEnd', scores, turnsPlayed, rounds: currentRound });
       
       // Save collected data
       let dataFile: string | undefined;
       if (collector) {
         collector.endRound(scores);
         dataFile = collector.finalize(scores);
-        log({ event: 'dataSaved', file: dataFile }, verbose);
+        emit({ event: 'dataSaved', file: dataFile });
       }
       
       return { scores, turnsPlayed, rounds: currentRound, dataFile };
@@ -120,7 +144,7 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
     // the next round (hand refills to 10) or end the game.
     let state = await readGameState(page);
     if (state.hand.length === 0 && action === 'playCard') {
-      log({ event: 'roundComplete', message: 'Hand empty — waiting for next round or game end', round: currentRound }, verbose);
+      emit({ event: 'roundComplete', message: 'Hand empty — waiting for next round or game end', round: currentRound });
       let foundNewState = false;
       for (let retry = 0; retry < 20; retry++) {
         await page.waitForTimeout(1500);
@@ -130,7 +154,7 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
           return gs?.name === 'gameEnd' || gs?.name === 'endGame';
         });
         if (gameOver) {
-          log({ event: 'gameEnd', round: currentRound }, verbose);
+          emit({ event: 'gameEnd', round: currentRound });
           const scores = await getFinalScores(page);
           let dataFile: string | undefined;
           if (collector) {
@@ -158,7 +182,7 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
     // The turnsPlayed>0 guard prevents false-triggering on initial game join.
     if (state.hand.length >= 9 && lastHandSize < 9 && lastHandSize >= 0 && turnsPlayed > 0) {
       currentRound++;
-      log({ event: 'newRound', round: currentRound }, verbose);
+      emit({ event: 'newRound', round: currentRound });
       const hand = state.hand.map(h => h.cardValue as number);
       const board = state.board.rows.map(r => [...r]);
       roundStartBoard = board; // save for initialBoardCards in strategy state
@@ -176,7 +200,29 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
       const decisionTime = Date.now() - t0;
       
       if (delay) await page.waitForTimeout(delay);
-      await playCard(page, state.hand, card);
+
+      // Attempt card play — on failure, emit enriched error with full context
+      const stateReadAt = Date.now();
+      try {
+        await playCard(page, state.hand, card);
+      } catch (err) {
+        const dom = await captureErrorContext(page);
+        logError({
+          event: 'error',
+          message: (err as Error).message,
+          context: {
+            action: 'playCard',
+            targetCard: card,
+            stateAgeMs: Date.now() - stateReadAt,
+            hand: state.hand.map(h => h.cardValue as number),
+            board: boardBefore,
+            dom,
+          },
+          lastEvents: [...eventBuffer],
+        });
+        throw err;
+      }
+
       lastPlayedCard = card; // track for potential row pick that follows
       turnsPlayed++;
 
@@ -207,14 +253,14 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
         },
       });
 
-      log({
+      emit({
         event: 'playCard',
         card,
         round: currentRound,
         turn: currentTurn,
         handSize: state.hand.length - 1,
         decisionTime,
-      }, verbose);
+      });
 
     } else if (action === 'pickRow') {
       // Row pick: our played card was lower than all row tails, so we must
@@ -229,17 +275,38 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
       }
 
       if (delay) await page.waitForTimeout(delay);
-      await pickRow(page, rowIdx);
+
+      // Attempt row pick — on failure, emit enriched error with full context
+      const rowStateReadAt = Date.now();
+      try {
+        await pickRow(page, rowIdx);
+      } catch (err) {
+        const dom = await captureErrorContext(page);
+        logError({
+          event: 'error',
+          message: (err as Error).message,
+          context: {
+            action: 'pickRow',
+            targetRow: rowIdx,
+            stateAgeMs: Date.now() - rowStateReadAt,
+            hand: state.hand.map(h => h.cardValue as number),
+            board: state.board.rows.map(r => [...r]),
+            dom,
+          },
+          lastEvents: [...eventBuffer],
+        });
+        throw err;
+      }
 
       // Record row pick in data collection
       collector?.recordRowPick(rowIdx, state.board.rows.map(r => [...r]));
 
-      log({
+      emit({
         event: 'pickRow',
         row: rowIdx,
         round: currentRound,
         turn: turnsPlayed,
-      }, verbose);
+      });
     }
 
     // Wait for BGA animations to resolve (card placement, row clearing, etc.)

--- a/src/player/loop.ts
+++ b/src/player/loop.ts
@@ -220,6 +220,28 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
           },
           lastEvents: [...eventBuffer],
         });
+
+        // Before crashing: check if the game ended abruptly (e.g. a player quit).
+        // BGA may not cleanly emit gameEnd — it can silently transition to cardReveal
+        // or another terminal state. If the game is over, exit gracefully.
+        const abruptEnd = await page.evaluate(() => {
+          const gs = (window as any).gameui?.gamedatas?.gamestate;
+          const gsName: string = gs?.name ?? '';
+          // If we can't find the card and the gamestate is non-interactive,
+          // the game likely ended without a clean gameEnd transition.
+          return gsName !== 'cardSelect' && gsName !== 'playerTurn';
+        }).catch(() => true); // if evaluate fails, assume game ended
+
+        if (abruptEnd) {
+          emit({ event: 'gameAborted', reason: 'card not found in non-interactive state', gamestateName: dom.gamestateName });
+          const scores = await getFinalScores(page).catch(() => ({}));
+          if (collector) {
+            collector.endRound(scores);
+            collector.finalize(scores);
+          }
+          return { scores, turnsPlayed, rounds: currentRound };
+        }
+
         throw err;
       }
 

--- a/src/player/loop.ts
+++ b/src/player/loop.ts
@@ -31,6 +31,14 @@ import { playCard, pickRow } from './actor.js';
 import { log, logError } from './logger.js';
 import { GameCollector } from './collector.js';
 
+/** Safely extract message and stack from any thrown value. */
+function formatError(err: unknown): { message: string; stack?: string } {
+  if (err instanceof Error) {
+    return { message: err.message, ...(err.stack ? { stack: err.stack } : {}) };
+  }
+  return { message: String(err) };
+}
+
 export interface PlayOptions {
   strategy: Strategy;
   strategyName?: string;
@@ -113,7 +121,7 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
     const stamped = { ...entry, timestamp: new Date().toISOString() };
     eventBuffer.push(stamped);
     if (eventBuffer.length > RING_SIZE) eventBuffer.shift();
-    log(stamped as any, verbose);
+    log(stamped as any, verbose); // timestamp already set — log() won't overwrite
   }
 
   // Initialize strategy with game metadata
@@ -151,10 +159,11 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
       action = await waitForAction(page, timeout);
     } catch (err) {
       const dom = await captureErrorContext(page);
+      const { message, stack } = formatError(err);
       logError({
         event: 'error',
-        message: (err as Error).message,
-        context: { action: 'waitForAction', dom },
+        message,
+        context: { action: 'waitForAction', dom, ...(stack ? { stack } : {}) },
         lastEvents: [...eventBuffer],
       });
       throw err;
@@ -179,6 +188,7 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
     // After playing 10 cards, hand is empty. We need to wait for BGA to deal
     // the next round (hand refills to 10) or end the game.
     let state = await readGameState(page);
+    let stateReadAt = Date.now(); // track when state was read for staleAgeMs diagnostics
     if (state.hand.length === 0 && action === 'playCard') {
       emit({ event: 'roundComplete', message: 'Hand empty — waiting for next round or game end', round: currentRound });
       let foundNewState = false;
@@ -238,14 +248,14 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
       if (delay) await page.waitForTimeout(delay);
 
       // Attempt card play — on failure, emit enriched error with full context
-      const stateReadAt = Date.now();
       try {
         await playCard(page, card);
       } catch (err) {
         const dom = await captureErrorContext(page);
+        const { message, stack } = formatError(err);
         logError({
           event: 'error',
-          message: (err as Error).message,
+          message,
           context: {
             action: 'playCard',
             targetCard: card,
@@ -253,6 +263,7 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
             hand: state.hand.map(h => h.cardValue as number),
             board: boardBefore,
             dom,
+            ...(stack ? { stack } : {}),
           },
           lastEvents: [...eventBuffer],
         });
@@ -343,21 +354,22 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
       if (delay) await page.waitForTimeout(delay);
 
       // Attempt row pick — on failure, emit enriched error with full context
-      const rowStateReadAt = Date.now();
       try {
         await pickRow(page, rowIdx);
       } catch (err) {
         const dom = await captureErrorContext(page);
+        const { message, stack } = formatError(err);
         logError({
           event: 'error',
-          message: (err as Error).message,
+          message,
           context: {
             action: 'pickRow',
             targetRow: rowIdx,
-            stateAgeMs: Date.now() - rowStateReadAt,
+            stateAgeMs: Date.now() - stateReadAt,
             hand: state.hand.map(h => h.cardValue as number),
             board: state.board.rows.map(r => [...r]),
             dom,
+            ...(stack ? { stack } : {}),
           },
           lastEvents: [...eventBuffer],
         });

--- a/src/player/loop.ts
+++ b/src/player/loop.ts
@@ -60,6 +60,31 @@ async function waitForAction(
 }
 
 /**
+ * After playing a card, wait for BGA to fully resolve the turn before we poll
+ * for the next action. Without this, `waitForAction` returns `playCard` again
+ * immediately because the gamestate stays `cardSelect` while waiting for other
+ * players — causing the agent to re-run the strategy and click a second card.
+ *
+ * Strategy: poll until gamestate is no longer `cardSelect`/`playerTurn` (i.e.
+ * BGA has moved into resolution — cardProcess, cardReveal, etc.), then return.
+ * The main loop resumes and calls `waitForAction` which will correctly wait
+ * for the next interactive state.
+ */
+async function waitForTurnResolution(page: Page, timeout: number): Promise<void> {
+  const startTime = Date.now();
+  while (Date.now() - startTime < timeout) {
+    const leftCardSelect = await page.evaluate(() => {
+      const gsName = (window as any).gameui?.gamedatas?.gamestate?.name ?? '';
+      // Wait until we leave the card-selection phase entirely
+      return gsName !== 'cardSelect' && gsName !== 'playerTurn';
+    });
+    if (leftCardSelect) return;
+    await page.waitForTimeout(300);
+  }
+  // Timeout is non-fatal — main waitForAction will handle it
+}
+
+/**
  * Play a full game from current page state until game ends.
  * Can be started mid-game (e.g. after reconnecting) — state is inferred from DOM.
  */
@@ -260,6 +285,12 @@ export async function playGame(page: Page, opts: PlayOptions): Promise<GameResul
         });
         if (check <= expectedSize) break;
       }
+
+      // Wait for BGA to leave the card-selection gamestate entirely before looping.
+      // This prevents waitForAction from firing 'playCard' again while other players
+      // are still selecting (gamestate stays 'cardSelect' until all have submitted).
+      // Fixes: agent re-running strategy and clicking a second card mid-turn.
+      await waitForTurnResolution(page, 30_000);
 
       // Record turn data
       collector?.recordTurn({

--- a/src/player/state-reader.ts
+++ b/src/player/state-reader.ts
@@ -122,8 +122,50 @@ export async function readGameState(page: Page): Promise<GameStateFromDOM> {
 }
 
 /**
- * Diagnostic: dump raw hand DOM info for debugging.
+ * Capture a diagnostic DOM snapshot for error reporting.
+ *
+ * Called from loop.ts catch blocks to attach live DOM state to error events.
+ * Reads only what's needed for debugging — does NOT re-read full game state
+ * (which might itself throw if the page is in a bad state).
  */
+export interface ErrorContext {
+  title: string;
+  gamestateName: string;
+  handItemCount: number;
+  /** Raw stock item IDs currently in hand — useful to see if card disappeared */
+  rawItems: number[];
+  rowArrowsVisible: boolean;
+}
+
+export async function captureErrorContext(page: Page): Promise<ErrorContext> {
+  try {
+    return await page.evaluate((() => {
+      /* eslint-disable no-undef */
+      const gu = (window as any).gameui;
+      const title = (window as any).document.getElementById('pagemaintitletext')?.textContent?.trim() ?? '';
+      const gamestateName = gu?.gamedatas?.gamestate?.name ?? 'unknown';
+
+      const items = gu?.playerHand?.getAllItems?.() ?? [];
+      const rawItems = items.map((i: any) => i.id);
+
+      // Check if any row arrow is currently visible/selectable (our row pick turn)
+      let rowArrowsVisible = false;
+      for (let r = 1; r <= 4; r++) {
+        const arrow = (window as any).document.getElementById(`row_slot_${r}_arrow`);
+        if (arrow && (arrow.classList.contains('selectable_row') || arrow.offsetParent !== null)) {
+          rowArrowsVisible = true;
+          break;
+        }
+      }
+
+      return { title, gamestateName, handItemCount: items.length, rawItems, rowArrowsVisible };
+      /* eslint-enable no-undef */
+    }) as any);
+  } catch {
+    // Page may be mid-navigation or crashed — return a safe fallback
+    return { title: '', gamestateName: 'unknown', handItemCount: -1, rawItems: [], rowArrowsVisible: false };
+  }
+}
 export async function diagnoseDom(page: Page): Promise<unknown> {
   return await page.evaluate((() => {
     const gu = (window as any).gameui;

--- a/src/player/state-reader.ts
+++ b/src/player/state-reader.ts
@@ -221,7 +221,8 @@ export async function detectAction(page: Page): Promise<PageAction> {
     // These occur during normal play AND when a player quits mid-game (which can push
     // BGA into cardReveal or similar without a clean gameEnd transition).
     // Returning 'waiting' here prevents the fallback below from falsely triggering 'playCard'.
-    const NON_INTERACTIVE = ['cardReveal', 'resolveStack', 'betweenRounds', 'newRound', 'nextRound'];
+    // NOTE: add new states here as they are discovered in live play.
+    const NON_INTERACTIVE = ['cardReveal', 'cardProcess', 'resolveStack', 'betweenRounds', 'newRound', 'nextRound'];
     if (NON_INTERACTIVE.includes(gsName)) return 'waiting';
 
     const titleEl = (window as any).document.getElementById('pagemaintitletext');

--- a/src/player/state-reader.ts
+++ b/src/player/state-reader.ts
@@ -167,6 +167,10 @@ export async function captureErrorContext(page: Page): Promise<ErrorContext> {
     return { title: '', gamestateName: 'unknown', handItemCount: -1, rawItems: [], rowArrowsVisible: false };
   }
 }
+/**
+ * Debug utility — dump raw DOM state for manual investigation.
+ * Not used in normal play; kept for ad-hoc troubleshooting via REPL/agent.
+ */
 export async function diagnoseDom(page: Page): Promise<unknown> {
   return await page.evaluate((() => {
     const gu = (window as any).gameui;
@@ -247,9 +251,9 @@ export async function detectAction(page: Page): Promise<PageAction> {
         if (el.classList.contains('selectable_row')) anySelectable = true;
       });
       if (anySelectable) return 'pickRow';
-      // Last resort: if title explicitly starts with "you", trust it
-      if (title.startsWith('you')) return 'pickRow';
-      // Otherwise it's opponent's turn to pick — we wait
+      // NOT our turn — title says "X must take a row" where X is opponent.
+      // Do NOT fall back to title.startsWith('you') — BGA title text can be stale
+      // or misleading. Only selectable_row class is authoritative for our turn.
       return 'waiting';
     }
 

--- a/src/player/state-reader.ts
+++ b/src/player/state-reader.ts
@@ -148,11 +148,12 @@ export async function captureErrorContext(page: Page): Promise<ErrorContext> {
       const items = gu?.playerHand?.getAllItems?.() ?? [];
       const rawItems = items.map((i: any) => i.id);
 
-      // Check if any row arrow is currently visible/selectable (our row pick turn)
+      // Check if any row arrow is currently selectable (our row pick turn).
+      // Only 'selectable_row' class is reliable — arrows stay visible during opponent picks.
       let rowArrowsVisible = false;
       for (let r = 1; r <= 4; r++) {
         const arrow = (window as any).document.getElementById(`row_slot_${r}_arrow`);
-        if (arrow && (arrow.classList.contains('selectable_row') || arrow.offsetParent !== null)) {
+        if (arrow && arrow.classList.contains('selectable_row')) {
           rowArrowsVisible = true;
           break;
         }
@@ -235,17 +236,15 @@ export async function detectAction(page: Page): Promise<PageAction> {
 
     // Row pick detection — tricky because BGA shows the same title structure
     // for both "You must take a row" and "OpponentName must take a row".
-    // We verify it's our turn by checking if row arrows are actually clickable.
+    // We verify it's our turn ONLY via the 'selectable_row' class — BGA adds
+    // this class exclusively when it's our turn to pick. Do NOT fall back to
+    // offsetParent/visibility checks: row arrows remain rendered and visible
+    // in the DOM during opponent picks, so visibility alone is unreliable.
     if (title.includes('must take a row') || title.includes('must choose a row')) {
       const arrows = (window as any).document.querySelectorAll('#row_slot_1_arrow, #row_slot_2_arrow, #row_slot_3_arrow, #row_slot_4_arrow');
       let anySelectable = false;
       arrows.forEach((el: any) => {
-        // BGA adds 'selectable_row' class to arrows only when it's our turn.
-        // Also check computed visibility as a secondary signal.
-        if (el.classList.contains('selectable_row') || 
-            el.style.display !== 'none' && el.style.visibility !== 'hidden' && el.offsetParent !== null) {
-          anySelectable = true;
-        }
+        if (el.classList.contains('selectable_row')) anySelectable = true;
       });
       if (anySelectable) return 'pickRow';
       // Last resort: if title explicitly starts with "you", trust it

--- a/src/player/state-reader.ts
+++ b/src/player/state-reader.ts
@@ -212,9 +212,17 @@ export type PageAction = 'playCard' | 'pickRow' | 'waiting' | 'gameEnd';
 export async function detectAction(page: Page): Promise<PageAction> {
   return await page.evaluate((() => {
     const gs = (window as any).gameui?.gamedatas?.gamestate;
+    const gsName: string = gs?.name ?? '';
 
-    // Game end is always authoritative from gamestate
-    if (gs?.name === 'gameEnd') return 'gameEnd';
+    // Game end — check multiple possible state names BGA uses
+    if (gsName === 'gameEnd' || gsName === 'endGame' || gsName === 'gameOver') return 'gameEnd';
+
+    // BGA non-interactive resolution states — cards are flying/animating, not our turn.
+    // These occur during normal play AND when a player quits mid-game (which can push
+    // BGA into cardReveal or similar without a clean gameEnd transition).
+    // Returning 'waiting' here prevents the fallback below from falsely triggering 'playCard'.
+    const NON_INTERACTIVE = ['cardReveal', 'resolveStack', 'betweenRounds', 'newRound', 'nextRound'];
+    if (NON_INTERACTIVE.includes(gsName)) return 'waiting';
 
     const titleEl = (window as any).document.getElementById('pagemaintitletext');
     const title = (titleEl?.textContent ?? '').toLowerCase();
@@ -247,7 +255,9 @@ export async function detectAction(page: Page): Promise<PageAction> {
 
     // Fallback: gamestate name covers round transitions where title hasn't updated yet.
     // After BGA deals new cards, gamestate changes to 'cardSelect' before the title updates.
-    if (gs?.name === 'cardSelect' || gs?.name === 'playerTurn') {
+    // NOTE: this only fires for cardSelect/playerTurn — non-interactive states are handled
+    // above and must not reach here, or they'd incorrectly trigger playCard.
+    if (gsName === 'cardSelect' || gsName === 'playerTurn') {
       const handItems = (window as any).gameui?.playerHand?.getAllItems?.() ?? [];
       if (handItems.length > 0) return 'playCard';
     }


### PR DESCRIPTION
Closes #8

## What

When the player crashed, the error log was nearly useless — just a bare message with no context. This PR adds rich diagnostic output to every error event.

## Changes

### `logger.ts`
- Added `logError()` — always emits to **stderr**, never gated by `--verbose`

### `state-reader.ts`
- Added `captureErrorContext(page)` — snapshots live DOM state at the moment of failure:
  - Page title text
  - Current gamestate name
  - Raw hand item count + stock IDs from `getAllItems()`
  - Whether row arrows are visible/selectable

### `loop.ts`
- Added a **10-event ring buffer** — every emitted event is kept in memory and attached to error events for replay context
- Replaced bare `log()` calls with `emit()` helper that feeds the ring buffer
- Wrapped `playCard()`, `pickRow()`, and `waitForAction()` in try/catch that emit enriched error events before re-throwing

## Example enriched error event

```jsonl
{"event":"error","message":"Failed to play card 62: Card 62 not found","context":{"action":"playCard","targetCard":62,"stateAgeMs":3200,"hand":[62,78,34,19],"board":[[5,22],[10,31],[44,55,60],[88]],"dom":{"title":"You must choose a card to play","gamestateName":"cardSelect","handItemCount":3,"rawItems":[1042,1043,1044],"rowArrowsVisible":false}},"lastEvents":[...],"timestamp":"..."}
```

## Tests

All 413 tests pass.
